### PR TITLE
Update temp path usage

### DIFF
--- a/embdgen-cominit/tests/test_CominitContent.py
+++ b/embdgen-cominit/tests/test_CominitContent.py
@@ -5,12 +5,11 @@ import pytest
 from cryptography.hazmat.primitives.asymmetric import rsa, ec, padding
 from cryptography.hazmat.primitives import serialization, hashes
 
-from embdgen.core.utils.image import get_temp_path
+from embdgen.core.utils.image import BuildLocation
 from embdgen.core.utils.SizeType import SizeType
 from embdgen.plugins.content.CominitContent import CominitContent
 from embdgen.plugins.content.RawContent import RawContent
 from embdgen.plugins.content.VerityContent import VerityContent
-
 
 
 # Note: only 4096 bytes signature supported, because cominit
@@ -31,7 +30,8 @@ def verify_signature(metadata: bytes, sig: bytes):
 
 class TestCominitContent:
     def test_plain(self, tmp_path: Path):
-        get_temp_path.TEMP_PATH = tmp_path
+        BuildLocation()(tmp_path)
+
         image_file = tmp_path / "image"
         content_file = tmp_path / "content"
         content_file.write_bytes(b"\1" * 4096)
@@ -68,9 +68,8 @@ class TestCominitContent:
 
         verify_signature(metadata, sig)
 
-
     def test_verity(self, tmp_path):
-        get_temp_path.TEMP_PATH = tmp_path
+        BuildLocation()(tmp_path)
         image_file = tmp_path / "image"
         content_file = tmp_path / "content"
         content_file.write_bytes(b"\1" * 4096 * 2)
@@ -138,7 +137,6 @@ class TestCominitContent:
         with pytest.raises(KeyError):
             obj.prepare()
 
-
     def test_verity_writable(self):
         obj = CominitContent()
         obj.dm_type = "verity"
@@ -150,7 +148,8 @@ class TestCominitContent:
             obj.prepare()
 
     def test_verity_invalid_bocksizes(self, tmp_path):
-        get_temp_path.TEMP_PATH = tmp_path
+        BuildLocation()(tmp_path)
+
         image_file = tmp_path / "image"
         content_file = tmp_path / "content"
         content_file.write_bytes(b"\1" * 512 * 2)

--- a/embdgen-core/src/embdgen/core/cli/CLI.py
+++ b/embdgen-core/src/embdgen/core/cli/CLI.py
@@ -51,8 +51,7 @@ class CLI:
             if options.format is None:
                 self.fatal("Unable to detect the format of the config file")
 
-        BuildLocation()(options.tempdir)
-
+        BuildLocation().set_path(options.tempdir)
         label = self.factory.by_type(options.format)().load(options.filename) # type: ignore
 
         print("Preparing...")

--- a/embdgen-core/src/embdgen/core/cli/CLI.py
+++ b/embdgen-core/src/embdgen/core/cli/CLI.py
@@ -7,7 +7,8 @@ from dataclasses import dataclass
 from argparse import ArgumentParser
 
 from ..config.Factory import Factory
-from ..utils.image import get_temp_path
+from ..utils.image import BuildLocation
+
 
 @dataclass(init=False)
 class Arguments:
@@ -15,6 +16,7 @@ class Arguments:
     output: Path
     tempdir: Path
     filename: Path
+
 
 class CLI:
     factory = Factory()
@@ -33,8 +35,9 @@ class CLI:
         self.register_config_loaders(parser)
         parser.add_argument("-o", "--output", default="image.raw", type=Path,
                             help="Output file name (default: image.raw)")
-        parser.add_argument("-t", "--tempdir", default="tmp", type=Path,
-                            help="Temporary directory (default: tmp)")
+        parser.add_argument(
+            "-t", "--tempdir", type=Path, help="Specify another temporary directory"
+        )
         parser.add_argument("filename", type=Path, help="Config file name")
         return parser
 
@@ -48,8 +51,7 @@ class CLI:
             if options.format is None:
                 self.fatal("Unable to detect the format of the config file")
 
-        get_temp_path.TEMP_PATH = options.tempdir # type: ignore
-        get_temp_path.TEMP_PATH.mkdir(parents=True, exist_ok=True) # type: ignore
+        BuildLocation()(options.tempdir)
 
         label = self.factory.by_type(options.format)().load(options.filename) # type: ignore
 
@@ -62,12 +64,13 @@ class CLI:
         print(f"\nWriting image to {options.output}")
         label.create(options.output)
 
+        BuildLocation().remove()
+
     def probe_format(self, filename: Path) -> Optional[str]:
         for name, typ in self.factory.class_map().items():
             if typ.probe(filename):
                 return name
         return None
-
 
     def fatal(self, msg: str) -> NoReturn:
         sys.exit(f"FATAL: {msg}")

--- a/embdgen-core/src/embdgen/core/utils/image.py
+++ b/embdgen-core/src/embdgen/core/utils/image.py
@@ -39,7 +39,7 @@ class BuildLocation:
     set_path = __call__
 
     def remove(self) -> None:
-        if self.path is not None and os.path.exists(self.path):
+        if self.path is not None and self.path.exists():
             shutil.rmtree(self.path)
 
     @staticmethod

--- a/embdgen-core/src/embdgen/core/utils/image.py
+++ b/embdgen-core/src/embdgen/core/utils/image.py
@@ -29,7 +29,7 @@ class BuildLocation:
             )
         return cls.__instance
 
-    def __call__(self, p: Path | None) -> BuildLocation:
+    def __call__(self, p: Path | None = None) -> BuildLocation:
         if p is not None:
             self.remove()
             self.path = p
@@ -39,6 +39,10 @@ class BuildLocation:
     def remove(self) -> None:
         if self.path is not None and os.path.exists(self.path):
             shutil.rmtree(self.path)
+
+    @staticmethod
+    def get_path() -> Path | None:
+        return BuildLocation().path
 
 
 def create_empty_image(filename: Path, size: int) -> None:
@@ -102,12 +106,5 @@ def copy_sparse(out_file: io.BufferedIOBase, in_file: io.BufferedIOBase, size: O
         out_file.seek(cur_pos)
 
 
-def get_temp_path() -> Path:
-    bl = BuildLocation()
-    if bl.path is not None:
-        return bl.path
-    raise Exception("Temporary path was not initalised")
-
-
 def get_temp_file(ext: str="") -> Path:
-    return Path(tempfile.mktemp(dir=get_temp_path(), suffix=ext))
+    return Path(tempfile.mktemp(dir=BuildLocation().get_path(), suffix=ext))

--- a/embdgen-core/src/embdgen/core/utils/image.py
+++ b/embdgen-core/src/embdgen/core/utils/image.py
@@ -103,7 +103,10 @@ def copy_sparse(out_file: io.BufferedIOBase, in_file: io.BufferedIOBase, size: O
 
 
 def get_temp_path() -> Path:
-    return BuildLocation().path
+    bl = BuildLocation()
+    if bl.path is not None:
+        return bl.path
+    raise Exception("Temporary path was not initalised")
 
 
 def get_temp_file(ext: str="") -> Path:

--- a/embdgen-core/src/embdgen/core/utils/image.py
+++ b/embdgen-core/src/embdgen/core/utils/image.py
@@ -36,6 +36,8 @@ class BuildLocation:
             self.path.mkdir(parents=True, exist_ok=True)
         return self
 
+    set_path = __call__
+
     def remove(self) -> None:
         if self.path is not None and os.path.exists(self.path):
             shutil.rmtree(self.path)

--- a/embdgen-core/src/embdgen/core/utils/image.py
+++ b/embdgen-core/src/embdgen/core/utils/image.py
@@ -30,8 +30,8 @@ class BuildLocation:
         return cls.__instance
 
     def __call__(self, p: Path | None) -> BuildLocation:
-        self.remove()
         if p is not None:
+            self.remove()
             self.path = p
             self.path.mkdir(parents=True, exist_ok=True)
         return self

--- a/embdgen-core/src/embdgen/plugins/content/ArchiveContent.py
+++ b/embdgen-core/src/embdgen/plugins/content/ArchiveContent.py
@@ -25,9 +25,9 @@ class ArchiveContent(FilesContentProvider):
         return self._files or []
 
     def prepare(self) -> None:
-        self._tmpDir = TemporaryDirectory(
+        self._tmpDir = TemporaryDirectory(  # pylint: disable=consider-using-with
             dir=BuildLocation().get_path()
-        )  # pylint: disable=consider-using-with
+        )
         tmpDir = Path(self._tmpDir.name)
 
         self._fakeroot.run([

--- a/embdgen-core/src/embdgen/plugins/content/ArchiveContent.py
+++ b/embdgen-core/src/embdgen/plugins/content/ArchiveContent.py
@@ -6,7 +6,7 @@ from tempfile import TemporaryDirectory
 
 from embdgen.core.utils.class_factory import Config
 from embdgen.core.content.FilesContentProvider import FilesContentProvider
-from embdgen.core.utils.image import get_temp_path
+from embdgen.core.utils.image import BuildLocation
 
 @Config("archive")
 class ArchiveContent(FilesContentProvider):
@@ -25,7 +25,9 @@ class ArchiveContent(FilesContentProvider):
         return self._files or []
 
     def prepare(self) -> None:
-        self._tmpDir = TemporaryDirectory(dir=get_temp_path()) #pylint: disable=consider-using-with
+        self._tmpDir = TemporaryDirectory(
+            dir=BuildLocation().get_path()
+        )  # pylint: disable=consider-using-with
         tmpDir = Path(self._tmpDir.name)
 
         self._fakeroot.run([
@@ -35,7 +37,6 @@ class ArchiveContent(FilesContentProvider):
         ], check=True)
 
         self._files = list(tmpDir.iterdir())
-
 
     def __repr__(self) -> str:
         return f"{self.__class__.__name__}({self.archive})"

--- a/embdgen-core/src/embdgen/plugins/content/Ext4Content.py
+++ b/embdgen-core/src/embdgen/plugins/content/Ext4Content.py
@@ -9,7 +9,12 @@ import shutil
 from embdgen.core.utils.class_factory import Config
 from embdgen.core.content.BinaryContent import BinaryContent
 from embdgen.core.content.FilesContentProvider import FilesContentProvider
-from embdgen.core.utils.image import create_empty_image, copy_sparse, get_temp_file, get_temp_path
+from embdgen.core.utils.image import (
+    create_empty_image,
+    copy_sparse,
+    get_temp_file,
+    BuildLocation,
+)
 from embdgen.core.utils.FakeRoot import FakeRoot
 
 
@@ -30,7 +35,7 @@ class Ext4Content(BinaryContent):
     def _prepare_result(self):
         create_empty_image(self.result_file, self.size.bytes)
 
-        with TemporaryDirectory(dir=get_temp_path()) as diro:
+        with TemporaryDirectory(dir=BuildLocation().get_path()) as diro:
             tmp_dir = Path(diro)
             for file in self.content.files:
                 if file.is_dir():
@@ -43,7 +48,6 @@ class Ext4Content(BinaryContent):
                 "-d", diro,
                 self.result_file
             ], check=True)
-
 
     def do_write(self, file: io.BufferedIOBase):
         with open(self.result_file, "rb") as in_file:

--- a/embdgen-core/src/embdgen/plugins/content_generator/SplitArchiveContentGenerator.py
+++ b/embdgen-core/src/embdgen/plugins/content_generator/SplitArchiveContentGenerator.py
@@ -37,9 +37,9 @@ class Split(FilesContentProvider):
     @property
     def tmpDir(self) -> TemporaryDirectory:
         if not self._tmpDir:
-            self._tmpDir = TemporaryDirectory(
+            self._tmpDir = TemporaryDirectory(  # pylint: disable=consider-using-with
                 dir=BuildLocation().get_path()
-            )  # pylint: disable=consider-using-with
+            )
         return self._tmpDir
 
     def init(self, base: "SplitArchiveContentGenerator", fakeroot: FakeRoot):

--- a/embdgen-core/src/embdgen/plugins/content_generator/SplitArchiveContentGenerator.py
+++ b/embdgen-core/src/embdgen/plugins/content_generator/SplitArchiveContentGenerator.py
@@ -11,7 +11,7 @@ from embdgen.core.utils.FakeRoot import FakeRoot
 from embdgen.core.utils.class_factory import Config
 
 from embdgen.core.content_generator.BaseContentGenerator import BaseContentGenerator
-from embdgen.core.utils.image import get_temp_path
+from embdgen.core.utils.image import BuildLocation
 from embdgen.plugins.content.ArchiveContent import ArchiveContent
 
 
@@ -37,7 +37,9 @@ class Split(FilesContentProvider):
     @property
     def tmpDir(self) -> TemporaryDirectory:
         if not self._tmpDir:
-            self._tmpDir = TemporaryDirectory(dir=get_temp_path()) #pylint: disable=consider-using-with
+            self._tmpDir = TemporaryDirectory(
+                dir=BuildLocation().get_path()
+            )  # pylint: disable=consider-using-with
         return self._tmpDir
 
     def init(self, base: "SplitArchiveContentGenerator", fakeroot: FakeRoot):

--- a/embdgen-core/tests/cli/test_cli.py
+++ b/embdgen-core/tests/cli/test_cli.py
@@ -18,7 +18,7 @@ class TestConfig(BaseConfig):
     @classmethod
     def probe(cls, _filename: Path) -> bool:
         return True
-    
+
 class TestConfig2(BaseConfig):
     was_called = False
     def load(self, filename: Path):
@@ -78,7 +78,7 @@ def test_complete(mocker: MockerFixture, capsys: pytest.CaptureFixture[str], tmp
     ])
 
     assert output_file.exists()
-    assert tmp_dir.exists()
+    assert not tmp_dir.exists()
 
     capsys.readouterr() # suppress output
 
@@ -98,6 +98,6 @@ def test_complete_explit_format(mocker: MockerFixture, capsys: pytest.CaptureFix
 
     assert TestConfig2.was_called
     assert output_file.exists()
-    assert tmp_dir.exists()
+    assert not tmp_dir.exists()
 
     capsys.readouterr() # suppress output

--- a/embdgen-core/tests/content/test_ArchiveContent.py
+++ b/embdgen-core/tests/content/test_ArchiveContent.py
@@ -5,8 +5,8 @@ import os
 from pathlib import Path
 import subprocess
 
-from embdgen.plugins.content.ArchiveContent import ArchiveContent
-from embdgen.core.utils.image import get_temp_path
+from embdgen.plugins.content.ArchiveContent import ArchiveContent  # type: ignore
+from embdgen.core.utils.image import BuildLocation
 from embdgen.core.utils.FakeRoot import FakeRoot
 
 @lru_cache
@@ -20,8 +20,8 @@ def calc_umask(mode: int) -> str:
     return f"{mode:o}"
 
 def test_simple(tmp_path: Path):
-    get_temp_path.TEMP_PATH = tmp_path
-    
+    BuildLocation()(tmp_path)
+
     prepare_dir = tmp_path / "prepare"
     archive = tmp_path / "archive.tar"
 
@@ -38,7 +38,6 @@ def test_simple(tmp_path: Path):
         "."
     ], check=True, cwd=prepare_dir)
 
-
     obj = ArchiveContent()
     obj.archive = archive
     obj.prepare()
@@ -47,7 +46,7 @@ def test_simple(tmp_path: Path):
 
 
 def test_fakeroot(tmp_path: Path):
-    get_temp_path.TEMP_PATH = tmp_path
+    BuildLocation()(tmp_path)
 
     save_file = tmp_path / "fakeroot.save"
     prepare_dir = tmp_path / "prepare"
@@ -58,7 +57,6 @@ def test_fakeroot(tmp_path: Path):
     (prepare_dir / "bar").mkdir()
     (prepare_dir / "a").touch()
     (prepare_dir / "bar" / "b").touch()
-
 
     fr = FakeRoot(save_file)
 

--- a/embdgen-core/tests/content/test_Ext4Content.py
+++ b/embdgen-core/tests/content/test_Ext4Content.py
@@ -12,7 +12,7 @@ import pytest
 from embdgen.plugins.content.Ext4Content import Ext4Content
 from embdgen.plugins.content.FilesContent import FilesContent
 from embdgen.plugins.content.ArchiveContent import ArchiveContent
-from embdgen.core.utils.image import get_temp_file, get_temp_path
+from embdgen.core.utils.image import get_temp_file, BuildLocation
 from embdgen.core.utils.SizeType import SizeType
 from embdgen.core.utils.FakeRoot import FakeRoot
 
@@ -117,7 +117,8 @@ class DebugFs():
 
 
 def test_from_files(tmp_path: Path):
-    get_temp_path.TEMP_PATH = tmp_path
+    BuildLocation()(tmp_path)
+
     image = tmp_path / "image"
     test_dir = tmp_path / "test_dir"
 
@@ -150,7 +151,7 @@ def test_from_files(tmp_path: Path):
 
 
 def test_from_archive_fakeroot(tmp_path: Path):
-    get_temp_path.TEMP_PATH = tmp_path
+    BuildLocation()(tmp_path)
 
     image = tmp_path / "image"
     archive = tmp_path / "archive.tar"

--- a/embdgen-core/tests/content/test_Fat32Content.py
+++ b/embdgen-core/tests/content/test_Fat32Content.py
@@ -7,7 +7,7 @@ import pytest
 
 from embdgen.plugins.content.FilesContent import FilesContent
 from embdgen.plugins.content.Fat32Content import Fat32Content
-from embdgen.core.utils.image import get_temp_path
+from embdgen.core.utils.image import BuildLocation
 from embdgen.core.utils.SizeType import SizeType
 
 class TestFat32Content:
@@ -15,7 +15,8 @@ class TestFat32Content:
         """
         Fat32 only supports files content right now
         """
-        get_temp_path.TEMP_PATH = tmp_path
+        BuildLocation()(tmp_path)
+
         image = tmp_path / "image"
 
         test_files = []

--- a/embdgen-core/tests/content/test_ResizeExt4Content.py
+++ b/embdgen-core/tests/content/test_ResizeExt4Content.py
@@ -7,7 +7,7 @@ import pytest
 
 from embdgen.plugins.content.ResizeExt4Content import ResizeExt4Content
 from embdgen.plugins.content.RawContent import RawContent
-from embdgen.core.utils.image import create_empty_image, get_temp_path
+from embdgen.core.utils.image import create_empty_image, BuildLocation
 from embdgen.core.utils.SizeType import SizeType
 
 
@@ -27,7 +27,7 @@ def get_ext4_size(filename: Path) -> int:
 
 class TestResizeExt4:
     def test_resize_0(self, tmp_path: Path):
-        get_temp_path.TEMP_PATH = tmp_path
+        BuildLocation()(tmp_path)
         test_fs = tmp_path / "ext4.img"
 
         create_empty_image(str(test_fs), 10 * 1024 * 1024)
@@ -52,7 +52,7 @@ class TestResizeExt4:
         assert get_ext4_size(output) == get_ext4_size(test_fs), "Filesystem was not resized"
 
     def test_resize(self, tmp_path: Path):
-        get_temp_path.TEMP_PATH = tmp_path
+        BuildLocation()(tmp_path)
         test_fs = tmp_path / "ext4.img"
 
         create_empty_image(str(test_fs), 10 * 1024 * 1024)

--- a/embdgen-core/tests/content/test_VerityContent.py
+++ b/embdgen-core/tests/content/test_VerityContent.py
@@ -4,7 +4,7 @@ import pytest
 from pathlib import Path
 
 from embdgen.core.utils.SizeType import SizeType
-from embdgen.core.utils.image import create_empty_image, get_temp_path
+from embdgen.core.utils.image import create_empty_image, BuildLocation
 from embdgen.plugins.content.RawContent import RawContent
 from embdgen.plugins.content.VerityContent import VerityContent
 
@@ -39,7 +39,7 @@ class TestVerityContent():
         expected_root_hash: str,
         tmp_path: Path
     ):
-        get_temp_path.TEMP_PATH = tmp_path
+        BuildLocation()(tmp_path)
         metadata_file = tmp_path / "metadata.txt"
         input_file = tmp_path / "input"
         image_file = tmp_path / "image"
@@ -60,14 +60,13 @@ class TestVerityContent():
             obj.data_block_size = SizeType(data_block_size)
         if hash_block_size:
             obj.hash_block_size = SizeType(hash_block_size)
-        
 
         obj.use_internal_implementation = use_internal_implementation
         obj.prepare()
 
         assert metadata_file.exists() and metadata_file.stat().st_size > 200
 
-        #print(metadata_file.read_text())
+        # print(metadata_file.read_text())
 
         if expected_root_hash:
             assert [line.split(":") for line in  metadata_file.read_text().splitlines() if line.startswith("Root hash")][0][1].strip() == expected_root_hash
@@ -83,7 +82,7 @@ class TestVerityContent():
         assert image_file.stat().st_size == size + expected_hashtable_size
 
     def test_not_block_size_aligned(self, tmp_path: Path):
-        get_temp_path.TEMP_PATH = tmp_path
+        BuildLocation()(tmp_path)
         input_file = tmp_path / "input"
         create_empty_image(input_file, 4096 * 2 - 1)
 

--- a/embdgen-core/tests/content_generator/test_SplitArchiveContentGenerator.py
+++ b/embdgen-core/tests/content_generator/test_SplitArchiveContentGenerator.py
@@ -6,9 +6,8 @@ import subprocess
 from typing import Set
 import pytest
 
-from embdgen.core.utils.image import get_temp_path
+from embdgen.core.utils.image import BuildLocation
 from embdgen.plugins.content_generator.SplitArchiveContentGenerator import Split, SplitArchiveContentGenerator
-
 
 
 def create_split(name: str, root: str, remove_root: bool = False) -> Split:
@@ -97,7 +96,7 @@ class TestSplitArchiveContentGenerator:
         ], cwd=prep_dir, check=True)
 
     def test_simple(self, tmp_path: Path):
-        get_temp_path.TEMP_PATH = tmp_path
+        BuildLocation()(tmp_path)
 
         obj = SplitArchiveContentGenerator()
         obj.name = "split"
@@ -111,7 +110,6 @@ class TestSplitArchiveContentGenerator:
 
         obj.splits[0].prepare()
         obj.splits[1].prepare() # This should do nothing
-
 
         assert set(map(lambda x: str(x.relative_to(Path(obj.splits[0].tmpDir.name))), obj.splits[0].files)) == set(["mp1.file1", "mp1.file2"])
         assert get_tree(Path(obj.splits[0].tmpDir.name)) == set(["mp1.file1", "mp1.file2"])
@@ -130,7 +128,7 @@ class TestSplitArchiveContentGenerator:
         ])
 
     def test_non_exisiting_split(self, tmp_path: Path):
-        get_temp_path.TEMP_PATH = tmp_path
+        BuildLocation()(tmp_path)
 
         obj = SplitArchiveContentGenerator()
         obj.name = "split"

--- a/embdgen-core/tests/label/test_GPT.py
+++ b/embdgen-core/tests/label/test_GPT.py
@@ -6,7 +6,7 @@ import subprocess
 from dataclasses import dataclass
 import pytest
 
-from embdgen.core.utils.image import get_temp_path
+from embdgen.core.utils.image import BuildLocation
 from embdgen.core.utils.SizeType import SizeType
 
 from embdgen.plugins.label.GPT import GPT
@@ -71,11 +71,10 @@ class FdiskParser:
                     in_regions = True
 
 
-
-
 class TestGPT:
     def test_withParts(self, tmp_path):
-        get_temp_path.TEMP_PATH = tmp_path
+        BuildLocation()(tmp_path)
+
         image = tmp_path / "image"
         obj = GPT()
 
@@ -116,7 +115,6 @@ class TestGPT:
         assert len(fdisk.regions) == 2
         assert fdisk.regions[0].start_sector == 35
         assert fdisk.regions[1].start_sector == 37
-
 
     def test_overlap_primary(self):
         obj = GPT()

--- a/embdgen-core/tests/label/test_MBR.py
+++ b/embdgen-core/tests/label/test_MBR.py
@@ -6,7 +6,7 @@ from pathlib import Path
 import subprocess
 from dataclasses import dataclass
 
-from embdgen.core.utils.image import get_temp_path
+from embdgen.core.utils.image import BuildLocation
 from embdgen.core.utils.SizeType import SizeType
 
 from embdgen.plugins.label.MBR import MBR
@@ -82,8 +82,6 @@ class FdiskParser:
                     in_regions = True
 
 
-
-
 class TestMBR:
     def test_empty(self, tmp_path: Path):
         image = tmp_path / "image"
@@ -118,7 +116,8 @@ class TestMBR:
         assert fdisk.diskid == 0xdeadbeef
 
     def test_withParts(self, tmp_path):
-        get_temp_path.TEMP_PATH = tmp_path
+        BuildLocation()(tmp_path)
+
         image = tmp_path / "image"
         obj = MBR()
 

--- a/embdgen-core/tests/utils/test_image.py
+++ b/embdgen-core/tests/utils/test_image.py
@@ -5,7 +5,7 @@ import pytest
 from pathlib import Path
 from io import BytesIO
 
-from embdgen.core.utils.image import create_empty_image, copy_sparse, get_temp_path
+from embdgen.core.utils.image import create_empty_image, copy_sparse, BuildLocation
 
 
 def test_create_empty_image(tmp_path: Path):
@@ -26,7 +26,7 @@ def test_copy_sparse(tmp_path: Path):
 
     with file_path.open("rb+") as out_file:
         copy_sparse(out_file, in_file, 1024)
-    
+
     assert file_path.stat().st_size == 1024 * 1024
 
     with file_path.open("rb") as a_file:
@@ -89,4 +89,4 @@ def test_copy_spares_after_end(tmp_path: Path):
 
 def test_get_temp_path():
     """ Just for 100% coverage"""
-    assert isinstance(get_temp_path(), Path)
+    assert isinstance(BuildLocation().get_path(), Path)


### PR DESCRIPTION
Current implementation caused lots of problems with the integration to use emdggen as a library. This PR replaces it with the singleton which also defaults to a `/tmp/...` instead, so it helps use it elsewhere and have a better control.

Additionally, in some cases temporary directory was still kept around.

Needs to be merged to unblock https://github.com/isbm/berrymill/pull/89