### PR TITLE
Extend yaml plugin

### DIFF
--- a/embdgen-config-yaml/src/embdgen/plugins/config/YAML.py
+++ b/embdgen-config-yaml/src/embdgen/plugins/config/YAML.py
@@ -24,22 +24,24 @@ class YAML(BaseConfig):
         except (UnicodeDecodeError, y.YAMLError):
             return False
 
-    def load(self, filename: Path) -> BaseLabel:
-        root_schema = y.OrValidator(
+    def _get_schema(self) -> y.OrValidator:
+        return y.OrValidator(
             LabelValidator(),
-            y.Map({
-                y.Optional('contents'): y.Seq(ContentGeneratorValidator()),
-                'image': LabelValidator()
-            })
+            y.Map(
+                {
+                    y.Optional("contents"): y.Seq(ContentGeneratorValidator()),
+                    "image": LabelValidator(),
+                }
+            ),
         )
 
+    def _get_label(self, cfg) -> BaseLabel:
+        return cfg["image"].value if cfg.is_mapping() and "image" in cfg else cfg.value
+
+    def load(self, filename: Path) -> BaseLabel:
         ContentRegistry.instance().clear()
         with filename.open(encoding="utf-8") as f:
-            conf = y.load(f.read(), root_schema)
+            return self._get_label(y.load(f.read(), self._get_schema()))
 
-        if conf.is_mapping() and "image" in conf:
-            image = conf["image"].value
-        else:
-            image = conf.value
-
-        return image
+    def load_str(self, data: str) -> BaseLabel:
+        return self._get_label(y.load(data, schema=self._get_schema()))

--- a/embdgen-core/src/embdgen/core/config/BaseConfig.py
+++ b/embdgen-core/src/embdgen/core/config/BaseConfig.py
@@ -13,4 +13,12 @@ class BaseConfig(ABC):
 
     @abstractmethod
     def load(self, filename: Path) -> BaseLabel:
-        pass
+        """
+        Load configuration from a filename
+        """
+
+    @abstractmethod
+    def load_str(self, data: str) -> BaseLabel:
+        """
+        Load configuration from configuration string source
+        """

--- a/embdgen-core/tests/cli/test_cli.py
+++ b/embdgen-core/tests/cli/test_cli.py
@@ -15,6 +15,9 @@ class TestConfig(BaseConfig):
     def load(self, filename: Path):
         return MBR()
 
+    def load_str(self, data: str):
+        return MBR()
+
     @classmethod
     def probe(cls, _filename: Path) -> bool:
         return True
@@ -22,6 +25,10 @@ class TestConfig(BaseConfig):
 class TestConfig2(BaseConfig):
     was_called = False
     def load(self, filename: Path):
+        self.__class__.was_called = True
+        return MBR()
+
+    def load_str(self, data: str):
         self.__class__.was_called = True
         return MBR()
 

--- a/embdgen-core/tests/config/test_BaseConfig.py
+++ b/embdgen-core/tests/config/test_BaseConfig.py
@@ -8,6 +8,9 @@ class ConfigFoo(BaseConfig):
     def load(self, filename: Path) -> BaseLabel:
         return None
 
+    def load_str(self, data: str) -> BaseLabel:
+        return None
+
 def test_BaseConfig():
     c = ConfigFoo()
     assert c.probe(Path("")) is False


### PR DESCRIPTION
Current yaml plugin allows loading config only from the external file.
When using `embdgen` as a library, there should be another way to load
the configuration, which might be specified elsewhere.

