### PR TITLE
fat/ext: allow creation of empty partition

### DIFF
--- a/embdgen-core/tests/test_utils/SimpleCommandParser.py
+++ b/embdgen-core/tests/test_utils/SimpleCommandParser.py
@@ -1,0 +1,31 @@
+import abc
+import re
+import subprocess
+from typing import Dict, Tuple, Callable, Iterable
+
+class SimpleCommandParser(abc.ABC):
+    ATTRIBUTE_MAP: Dict[str, Tuple[str, Callable[[str], any]]] = {}
+
+    ok: bool
+    error: str
+
+    def __init__(self, command: Iterable[str]) -> None:
+        ret = subprocess.run(
+            command,
+            check=False,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            encoding="utf8"
+        )
+        self.error = ret.stderr
+        self.ok = ret.returncode == 0
+
+        for line in ret.stdout.splitlines():
+            splits = re.split(r":\s+", line.strip(), 1)
+            if len(splits) != 2:
+                continue
+            key, value = splits
+            key, conv = self.ATTRIBUTE_MAP.get(key.strip(), (None, None))
+            if not key or not conv:
+                continue
+            setattr(self, key, conv(value.strip()))

--- a/embdgen-core/tests/test_utils/__init__.py
+++ b/embdgen-core/tests/test_utils/__init__.py
@@ -1,0 +1,1 @@
+from .SimpleCommandParser import SimpleCommandParser


### PR DESCRIPTION
Allow creation of empty ext4 and fat32 partitions, by just omitting the content attribute.