### PR TITLE
MBR: add extended partition support

### DIFF
--- a/embdgen-core/pyproject.toml
+++ b/embdgen-core/pyproject.toml
@@ -28,7 +28,8 @@ classifiers = [
 requires-python = ">=3.9"
 dependencies = [
     "pyparted",
-    "fallocate"
+    "fallocate",
+    "typing-extensions"
 ]
 
 [project.urls]

--- a/embdgen-core/src/embdgen/core/label/BaseLabel.py
+++ b/embdgen-core/src/embdgen/core/label/BaseLabel.py
@@ -13,6 +13,53 @@ from embdgen.core.utils.image import create_empty_image
 from ..utils.class_factory import Config
 from ..region import BaseRegion
 
+class PartedInterface:
+    """
+    Contextmanager interface to parted label creation.
+
+    When used as a context manager, the class will automatically
+    commit the changes to the disk.
+    """
+
+    _device: parted.Device
+    _disk: parted.Disk
+    _label_type: str
+
+    def __init__(self, filename: Path, label_type: str) -> None:
+        self._label_type = label_type
+        self._device = parted.getDevice(filename.as_posix())
+        self._disk = parted.freshDisk(self._device, label_type)
+
+    def __enter__(self) -> "PartedInterface":
+        return self
+
+    def __exit__(self, exc_type, exc_value, traceback) -> None:
+        self._disk.commit()
+
+    def add_extended_partition(self, start: int, length: int):
+        """Create an extended partition"""
+        geometry = parted.Geometry(self._device, start=start, length=length)
+        partition = parted.Partition(
+            disk=self._disk,
+            type=parted.PARTITION_EXTENDED,
+            geometry=geometry
+        )
+        self._disk.addPartition(partition=partition, constraint=parted.Constraint(exactGeom=geometry))
+
+    def add_partition(self, part: PartitionRegion, logical: bool=False, boot_partition: bool=False):
+        """Create a normal logical partition"""
+        geometry = parted.Geometry(self._device, start=part.start.sectors, length=part.size.sectors)
+        partition = parted.Partition(
+            disk=self._disk,
+            type=parted.PARTITION_LOGICAL if logical else parted.PARTITION_NORMAL,
+            geometry=geometry,
+            fs=parted.FileSystem(part.fstype, geometry=geometry)
+        )
+        if boot_partition:
+            partition.setFlag(parted.PARTITION_BOOT)
+        if self._label_type == "msdos":
+            partition.setFlag(parted.PARTITION_LBA)
+        self._disk.addPartition(partition=partition, constraint=parted.Constraint(exactGeom=geometry))
 
 @Config('parts')
 @Config('boot_partition', optional=True)
@@ -51,51 +98,27 @@ class BaseLabel(abc.ABC):
             cur_offset += part.size
 
     def _create_partition_table(self, filename: Path, ptType: str) -> None:
-        device = parted.getDevice(filename.as_posix())
-        disk = parted.freshDisk(device, ptType)
+        with PartedInterface(filename, ptType) as pInt:
 
-        def is_partition(x: BaseRegion) -> TypeGuard[PartitionRegion]:
-            return isinstance(x, PartitionRegion)
+            def is_partition(x: BaseRegion) -> TypeGuard[PartitionRegion]:
+                return isinstance(x, PartitionRegion)
 
-        partitions = list(filter(is_partition, self.parts))
-        need_extended = ptType == "msdos" and len(partitions) > 4
+            partitions = list(filter(is_partition, self.parts))
+            need_extended = ptType == "msdos" and len(partitions) > 4
 
-        for partIndex, part in enumerate(partitions):
-            part_type = parted.PARTITION_NORMAL
-            if need_extended:
-                if partIndex >= 3:
-                    part_type = parted.PARTITION_LOGICAL
-
-                if partIndex == 3:
+            for partIndex, part in enumerate(partitions):
+                if need_extended and partIndex == 3:
                     # In the extended Partition Size, + 1 is added to include the size of the first EBR Header
-                    extPartLen = self.parts[-1].start.sectors + self.parts[-1].size.sectors - part.start.sectors + 1
-
-                    geometryExtended = parted.Geometry(device, start=(part.start.sectors - 1), length=extPartLen)
-
-                    partitionExtended = parted.Partition(
-                        disk=disk,
-                        type=parted.PARTITION_EXTENDED,
-                        geometry=geometryExtended
-                    )
-                    disk.addPartition(
-                        partition=partitionExtended,
-                        constraint=parted.Constraint(exactGeom=geometryExtended)
+                    pInt.add_extended_partition(
+                        part.start.sectors - 1,
+                        self.parts[-1].start.sectors + self.parts[-1].size.sectors - part.start.sectors + 1
                     )
 
-            geometry = parted.Geometry(device, start=part.start.sectors, length=part.size.sectors)
-            partition = parted.Partition(
-                disk=disk,
-                type=part_type,
-                geometry=geometry,
-                fs=parted.FileSystem(part.fstype, geometry=geometry)
-            )
-
-            if ptType == "msdos":
-                partition.setFlag(parted.PARTITION_LBA)
-            disk.addPartition(partition=partition, constraint=parted.Constraint(exactGeom=geometry))
-            if part.name == self.boot_partition:
-                partition.setFlag(parted.PARTITION_BOOT)
-        disk.commit()
+                pInt.add_partition(
+                    part,
+                    need_extended and partIndex >= 3,
+                    boot_partition=part.name == self.boot_partition
+                )
 
     def create(self, filename: Path) -> None:
         size = self.parts[-1].start + self.parts[-1].size

--- a/embdgen-core/src/embdgen/plugins/label/MBR.py
+++ b/embdgen-core/src/embdgen/plugins/label/MBR.py
@@ -5,6 +5,7 @@ import struct
 from typing import Optional
 from pathlib import Path
 
+from embdgen.plugins.region.PartitionRegion import PartitionRegion
 from embdgen.core.utils.class_factory import Config
 from embdgen.core.region.BaseRegion import BaseRegion
 from embdgen.core.utils.SizeType import SizeType
@@ -25,9 +26,26 @@ class MBRHeader(BaseRegion):
             out_file.seek(MBR.DISK_ID_OFFSET)
             out_file.write(struct.pack("I", self.diskid))
 
+class EBRHeader(BaseRegion):
+    start: SizeType
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.name = "EBR Header"
+        self.is_partition = False
+        self.size = SizeType(0x200)
+
+    def write(self, out_file: io.BufferedIOBase):
+        return
+
 @Config('diskid', optional=True)
 class MBR(BaseLabel):
-    """Master Boot Record (DOS) partition type"""
+    """
+    Master Boot Record (DOS) partition type
+
+    If more than 4 partitions are configured, all partitions starting
+    at the third will be created as extended partitions automatically.
+    """
     LABEL_TYPE = 'mbr'
 
     DISK_ID_OFFSET = 0x1B8
@@ -51,6 +69,28 @@ class MBR(BaseLabel):
     def prepare(self):
         if self.mbr_header not in self.parts:
             self.parts.append(self.mbr_header)
+
+        # if more than 4 partitions are present, then 4th partition should be extended partition
+        # EBR Headers should be added before each logical partition
+        partitionCnt = len(list(filter(lambda x: isinstance(x, PartitionRegion), self.parts)))
+
+        if partitionCnt > 4:
+            partPtr = 0
+            self.parts.sort(key=lambda x: x.start)
+
+            tmpPartList = []
+            for part in self.parts:
+                if isinstance(part, PartitionRegion):
+                    partPtr += 1
+
+                    if partPtr > 3:
+                        ebrHeader = EBRHeader()
+                        tmpPartList.append(ebrHeader)
+
+                tmpPartList.append(part)
+
+            self.parts = tmpPartList
+
         super().prepare()
 
     def create_partition_table(self, filename: Path):

--- a/embdgen-core/tests/label/test_MBR.py
+++ b/embdgen-core/tests/label/test_MBR.py
@@ -165,6 +165,7 @@ class TestMBR:
         assert len(fdisk.regions) == 2
         assert fdisk.regions[0].start_sector == 13
         assert fdisk.regions[0].type_id == FdiskParser.TYPE_LINUX_NATIVE
+        assert fdisk.regions[0].boot
         assert fdisk.regions[1].start_sector == 15
         assert fdisk.regions[1].type_id == FdiskParser.TYPE_FAT32_LBA
 

--- a/embdgen-core/tests/label/test_MBR.py
+++ b/embdgen-core/tests/label/test_MBR.py
@@ -9,10 +9,10 @@ from dataclasses import dataclass
 from embdgen.core.utils.image import BuildLocation
 from embdgen.core.utils.SizeType import SizeType
 
+from embdgen.plugins.content.EmptyContent import EmptyContent
 from embdgen.plugins.label.MBR import MBR
 from embdgen.plugins.region.EmptyRegion import EmptyRegion
 from embdgen.plugins.region.PartitionRegion import PartitionRegion
-from embdgen.plugins.region.RawRegion import RawRegion
 
 from embdgen.plugins.content.RawContent import RawContent
 from embdgen.plugins.content.FilesContent import FilesContent
@@ -30,6 +30,8 @@ class FdiskRegion:
 class FdiskParser:
     TYPE_FAT32_LBA = 0x0C
     TYPE_LINUX_NATIVE = 0x83
+    TYPE_EXTENDED = 0x05
+
 
     is_valid: bool = False
     diskid: int = None
@@ -81,6 +83,11 @@ class FdiskParser:
                 elif line.startswith("Device"):
                     in_regions = True
 
+    def __repr__(self) -> str:
+        out = []
+        for i, r in enumerate(self.regions):
+            out.append(f"{i} {r.start_sector:>5} - {r.start_sector + r.sectors:>5} ({r.sectors:>4} Sectors), {r.type_id}")
+        return "\n".join(out)
 
 class TestMBR:
     def test_empty(self, tmp_path: Path):
@@ -160,3 +167,61 @@ class TestMBR:
         assert fdisk.regions[0].type_id == FdiskParser.TYPE_LINUX_NATIVE
         assert fdisk.regions[1].start_sector == 15
         assert fdisk.regions[1].type_id == FdiskParser.TYPE_FAT32_LBA
+
+    def test_four_partitions_no_extended(self, tmp_path: Path):
+        BuildLocation().set_path(tmp_path)
+        image = tmp_path / "image"
+        obj = MBR()
+
+        for i in range(4):
+            part = PartitionRegion()
+            part.name = f"Part {i}"
+            part.size = SizeType.parse("1MB")
+            part.fstype = "ext4"
+            part.content = EmptyContent()
+            obj.parts.append(part)
+        obj.prepare()
+        obj.create(image)
+
+        fdisk = FdiskParser(image)
+        assert fdisk.is_valid
+        assert len(fdisk.regions) == 4
+        for i in range(4):
+            assert fdisk.regions[i].type_id == FdiskParser.TYPE_LINUX_NATIVE
+
+    def test_extended_with_empty(self, tmp_path: Path):
+        BuildLocation().set_path(tmp_path)
+        image = tmp_path / "image"
+        obj = MBR()
+
+        for i in range(8):
+            if i == 4:
+                part = EmptyRegion()
+                part.name = f"Empty {i}"
+                part.size = SizeType.parse("12 S")
+            else:
+                part = PartitionRegion()
+                part.name = f"Part {i}"
+                part.size = SizeType.parse("1MB")
+                part.fstype = "ext4"
+                part.content = EmptyContent()
+            obj.parts.append(part)
+        obj.prepare()
+        obj.create(image)
+
+        fdisk = FdiskParser(image)
+        assert fdisk.is_valid
+        assert len(fdisk.regions) == 8
+        pos = 1
+        for i in range(3):
+            assert fdisk.regions[i].type_id == FdiskParser.TYPE_LINUX_NATIVE
+            assert fdisk.regions[i].start_sector == pos
+            pos += SizeType.parse("1MB").sectors
+        assert fdisk.regions[3].type_id == FdiskParser.TYPE_EXTENDED
+        for i in range(4, 8):
+            pos += 1
+            assert fdisk.regions[i].type_id == FdiskParser.TYPE_LINUX_NATIVE
+            assert fdisk.regions[i].start_sector == pos
+            pos += SizeType.parse("1MB").sectors
+            if i == 4:
+                pos += 12 # Empty partition


### PR DESCRIPTION
With this update MBR can support more than 4 partitions, by automatically creating extended partitions