### PR TITLE
UBootEnvContent: add content module for creating a U-Boot environment

### DIFF
--- a/docs/_ext/config.py
+++ b/docs/_ext/config.py
@@ -74,7 +74,7 @@ class EmbdgenConfigDirective(SphinxDirective):
             path = path.parent.parent
             if path.name == "src":
                 path = path.parent
-            doc = (cls.__doc__ or entry_type).splitlines()
+            doc = (cls.__doc__ or entry_type).strip().splitlines()
 
             title = doc[0]
             if entry_type:
@@ -109,7 +109,7 @@ class EmbdgenConfigDirective(SphinxDirective):
                 else:
                     realtype = meta.typecls
                     typename = meta.typecls.__name__
-                
+
                 content.append(("" if meta.optional else "(required) ") + f"``{key}`` : {typename}", "")
                 if not meta.doc:
                     content.append("    N/A", "")

--- a/docs/core/plugins/content/UBootEnvContent.rst
+++ b/docs/core/plugins/content/UBootEnvContent.rst
@@ -1,0 +1,4 @@
+embdgen.plugins.content.UBootEnvContent
+=======================================
+
+.. automodule:: embdgen.plugins.content.UBootEnvContent

--- a/embdgen-config-yaml/src/embdgen/plugins/config/yaml/validator/StringDict.py
+++ b/embdgen-config-yaml/src/embdgen/plugins/config/yaml/validator/StringDict.py
@@ -1,0 +1,17 @@
+# SPDX-License-Identifier: GPL-3.0-only
+
+from typing import Dict
+import strictyaml as y
+from  strictyaml.parser import YAMLChunk
+
+class StringDict(y.MapPattern):
+    RESULT_TYPE = Dict[str, str]
+
+    def __init__(self):
+        super().__init__(y.Str(), y.Str())
+
+    def __call__(self, chunk: YAMLChunk) -> y.YAML:
+        self.validate(chunk)
+        v = y.YAML(chunk, validator=self)
+        v._value = {k._value: v._value for k, v in v._value.items()}
+        return v

--- a/embdgen-core/src/embdgen/core/utils/SizeType.py
+++ b/embdgen-core/src/embdgen/core/utils/SizeType.py
@@ -56,7 +56,10 @@ class SizeType():
 
     _bytes: Optional[int]
 
-    def __init__(self, bytes_val = None) -> None:
+    def __init__(self, bytes_val: Optional[int] = None) -> None:
+        if bytes_val and not isinstance(bytes_val, int):
+            self._bytes = None
+            raise Exception(f"SizeType expects int, not {type(bytes_val).__name__}")
         self._bytes = bytes_val
 
     @classmethod

--- a/embdgen-core/src/embdgen/core/utils/class_factory.py
+++ b/embdgen-core/src/embdgen/core/utils/class_factory.py
@@ -1,12 +1,20 @@
 # SPDX-License-Identifier: GPL-3.0-only
 
 import abc
-from typing import Any, List, Type, Dict, Optional, Union, get_origin, get_args, Generic, TypeVar, get_type_hints
+from typing import Any, List, Tuple, Type, Dict, Optional, Union, get_origin, get_args, Generic, TypeVar, get_type_hints
 from inspect import isclass, signature
 from pkgutil import iter_modules
 from importlib import import_module
 from types import ModuleType
 from dataclasses import dataclass
+
+def unpack_optional(var: Type) -> Tuple[bool, Type]:
+    if get_origin(var) == Union:
+        args = get_args(var)
+        if len(args) == 2 and type(None) in args:
+            return True, next(filter(lambda x: x is not type(None), args))
+
+    return False, var
 
 @dataclass
 class Meta():
@@ -75,7 +83,8 @@ def Config(name: str, doc="", optional=False):
         if not local_doc:
             local_doc = try_read_doc(cls, name)
 
-        meta = Meta(name, hints[name], local_doc, optional)
+        optional_from_type, real_type = unpack_optional(hints[name])
+        meta = Meta(name, real_type, local_doc, optional or optional_from_type)
         Meta.set(cls, meta)
         return cls
     return decorate
@@ -110,12 +119,11 @@ class FactoryBase(abc.ABC, Generic[T]):
 
     @classmethod
     def by_type(cls, type_any: Any) -> Optional[Type[T]]:
+        optional, real_type = unpack_optional(type_any)
+        if optional:
+            type_any = real_type
         if get_origin(type_any) == Union:
-            args = get_args(type_any)
-            if len(args) == 2 and type(None) in args: # This is Optional[T]
-                type_any = next(filter(lambda x: x is not type(None), args))
-            else:
-                raise Exception(f"Unexpected type in {cls}.by_type: {type_any}")
+            raise Exception(f"Unexpected type in {cls}.by_type: {type_any}")
         impl_class = cls.class_map().get(type_any, None)
 
         if impl_class or not cls.ALLOW_SUBCLASS:

--- a/embdgen-core/src/embdgen/core/utils/class_factory.py
+++ b/embdgen-core/src/embdgen/core/utils/class_factory.py
@@ -131,7 +131,7 @@ class FactoryBase(abc.ABC, Generic[T]):
 
         if isclass(type_any):
             for cur_type_class, impl_class in cls.class_map().items():
-                if get_origin(cur_type_class) is list:
+                if get_origin(cur_type_class) in [list, dict]:
                     continue
                 if issubclass(type_any, cur_type_class):
                     return impl_class

--- a/embdgen-core/src/embdgen/plugins/content/UBootEnvContent.py
+++ b/embdgen-core/src/embdgen/plugins/content/UBootEnvContent.py
@@ -1,0 +1,89 @@
+# SPDX-License-Identifier: GPL-3.0-only
+
+from io import BufferedIOBase
+from pathlib import Path
+import struct
+from typing import Dict, Optional
+import zlib
+
+from embdgen.core.content import BinaryContent
+from embdgen.core.utils.class_factory import Config
+
+
+@Config("vars")
+@Config("file")
+class UBootEnvContent(BinaryContent):
+    """
+    U-Boot Environment region
+
+    The variables passed in using file and vars is merged
+    with variables defined in vars overwriting variables
+    defined in the variables file.
+    """
+    CONTENT_TYPE ="uboot_env"
+
+    vars: Optional[Dict[str, str]] = None
+    """Variables placed in the environment"""
+
+    _file: Optional[Path] = None
+
+    _data: bytes
+
+    @property
+    def file(self) -> Optional[Path]:
+        """Variable file with key=value pairs"""
+        return self._file
+
+    @file.setter
+    def file(self, value: Optional[Path]):
+        if value and not value.exists():
+            raise Exception(f"File {value} does not exist")
+        self._file = value
+
+    def _parse_file(self) -> Dict[str, str]:
+        if not self.file:
+            return {}
+        out = {}
+        with self.file.open() as f:
+            for i, line in enumerate(f):
+                line = line.strip()
+                if line.startswith("#"):
+                    continue
+                parts = line.split("=", 1)
+                if len(parts) != 2:
+                    raise Exception(f"Invalid entry in U-Boot environment file (line {i + 1})")
+                out[parts[0].strip()] = parts[1].strip()
+        return out
+
+    def _merged_vars(self) -> Dict[str, str]:
+        out: Dict[str, str] = self._parse_file()
+
+        if self.vars:
+            out.update(self.vars)
+
+        return out
+
+    def prepare(self) -> None:
+        if self.size.is_undefined:
+            raise Exception("Size for U-Boot environment must be defined")
+
+        self._data = b""
+
+        res_vars = self._merged_vars()
+        for key in sorted(res_vars.keys()):
+            self._data += f"{key}={res_vars[key]}\0".encode()
+
+        self._data += b"\0"
+
+        if len(self._data) + 4 > self.size.bytes:
+            overflow = 4 + len(self._data) - self.size.bytes
+            raise Exception(f"U-Boot environment variables overflow storage area by {overflow} bytes")
+
+        self._data += b"\xFF" * (self.size.bytes - len(self._data) - 4)
+        self._data = struct.pack("<I", zlib.crc32(self._data)) + self._data
+
+    def do_write(self, file: BufferedIOBase) -> None:
+        file.write(self._data)
+
+    def __repr__(self) -> str:
+        return f"{self.__class__.__name__}(...)"

--- a/embdgen-core/tests/content/test_UBootEnvContent.py
+++ b/embdgen-core/tests/content/test_UBootEnvContent.py
@@ -1,0 +1,120 @@
+from io import BytesIO
+import pytest
+from pathlib import Path
+
+from embdgen.plugins.content.UBootEnvContent import UBootEnvContent
+from embdgen.core.utils.SizeType import SizeType
+
+class TestUBootEnvContent:
+    def test_assign_invalid_file(self):
+        with pytest.raises(Exception, match="File /path/i-do-not-exist does not exist"):
+            UBootEnvContent().file = Path("/path/i-do-not-exist")
+
+    def test_no_size(self):
+        obj = UBootEnvContent()
+        with pytest.raises(Exception, match="Size for U-Boot environment must be defined"):
+            obj.prepare()
+
+    def test_empty(self):
+        obj = UBootEnvContent()
+        obj.size = SizeType(1024)
+        obj.prepare()
+
+        img = BytesIO()
+        obj.write(img)
+        buf = img.getbuffer()
+        assert buf == b"\x97\xdb\x74\x10" + b"\0" + b"\xff" * 1019
+
+    def test_file(self, tmp_path: Path):
+        uboot_env = tmp_path / "uboot.env"
+        uboot_env.write_text(
+            """
+            C=D
+            A=B
+            #D=E
+            Empty=
+            A=Some other string with spaces
+            """.strip()
+        )
+        obj = UBootEnvContent()
+        obj.file = uboot_env
+        obj.size = SizeType(1024)
+        obj.prepare()
+        img = BytesIO()
+        obj.write(img)
+        buf = img.getbuffer()
+        data = b"A=Some other string with spaces\0C=D\0Empty=\0\0"
+        assert buf == b"\x08\x88\x28\xfa" + data + b"\xff" * (1024 - 4 - len(data))
+
+    def test_file_invalid_line(self, tmp_path: Path):
+        uboot_env = tmp_path / "uboot.env"
+        uboot_env.write_text(
+            """
+            C=D
+            A
+            #D=E
+            A=Some other string with spaces
+            """.strip()
+        )
+        obj = UBootEnvContent()
+        obj.file = uboot_env
+        obj.size = SizeType(1024)
+        with pytest.raises(Exception, match=r"Invalid entry in U-Boot environment file \(line 2\)"):
+            obj.prepare()
+
+    def test_vars(self):
+        obj = UBootEnvContent()
+        obj.vars = {
+            "C": "D",
+            "A": "Some other string with spaces",
+            "Empty": ""
+        }
+        obj.size = SizeType(1024)
+        obj.prepare()
+        img = BytesIO()
+        obj.write(img)
+        buf = img.getbuffer()
+        data = b"A=Some other string with spaces\0C=D\0Empty=\0\0"
+        assert buf == b"\x08\x88\x28\xfa" + data + b"\xff" * (1024 - 4 - len(data))
+
+    def test_file_and_vars(self, tmp_path: Path):
+        uboot_env = tmp_path / "uboot.env"
+        uboot_env.write_text(
+            """
+            C=D
+            Some Var = I will be overwritten by vars
+            """.strip()
+        )
+        obj = UBootEnvContent()
+        obj.file = uboot_env
+        obj.vars = {
+            "Some Var": "I overwrite var A from file",
+            "NewVar": "Additional var in vars"
+        }
+        obj.size = SizeType(1024)
+        obj.prepare()
+        img = BytesIO()
+        obj.write(img)
+        buf: memoryview = img.getbuffer()
+        data = b"C=D\0NewVar=Additional var in vars\0Some Var=I overwrite var A from file\0\0"
+        assert buf == b"\x9f\xac\xf1\xb0" + data + b"\xff" * (1024 - 4 - len(data))
+
+    def test_overflow(self):
+        obj = UBootEnvContent()
+        obj.size = SizeType(100)
+        obj.vars = {
+            "A": "x" * (100 - 4 - len(b"A=\0\0"))
+        }
+        obj.prepare()
+
+        obj.vars = {
+            "A": "x" * (100 - 4 - len(b"A=\0\0") + 1)
+        }
+        with pytest.raises(Exception, match=r"U-Boot environment variables overflow storage area by 1 byte"):
+            obj.prepare()
+
+        obj.vars = {
+            "A": "x" * (100 - 4 - len(b"A=\0\0") + 548)
+        }
+        with pytest.raises(Exception, match=r"U-Boot environment variables overflow storage area by 548 byte"):
+            obj.prepare()

--- a/embdgen-core/tests/utils/test_SizeType.py
+++ b/embdgen-core/tests/utils/test_SizeType.py
@@ -237,3 +237,10 @@ class TestSizeType:
     def test_bytes(self):
         with pytest.raises(Exception, match="SizeType.bytes called, when value is undefined"):
             SizeType().bytes
+
+    def test_constructor(self):
+        with pytest.raises(Exception, match="SizeType expects int, not str"):
+            SizeType("abc")
+        assert SizeType(None).is_undefined
+        assert SizeType(1234).bytes == 1234
+        assert SizeType(4096).sectors == 8

--- a/embdgen-core/tests/utils/test_class_factory.py
+++ b/embdgen-core/tests/utils/test_class_factory.py
@@ -46,11 +46,14 @@ class TestConfig:
     def test_decorate(self):
         @Config('foo')
         @Config('bar', optional=True)
+        @Config('opt')
         @Config('foobar')
         @Config('barfoo')
+        @Config('optprop')
         class FooBar():
             foo: int
             bar: str
+            opt: Optional[int]
             foobar: list
 
             @property
@@ -58,19 +61,26 @@ class TestConfig:
             @barfoo.setter
             def barfoo(self, value: int): pass
 
-        assert len(Meta.get(FooBar)) == 4
-        assert Meta.get(FooBar)['foo'] == Meta("foo", int, optional=False)
+            @property
+            def optprop(self) -> Optional[int]: pass
+            @optprop.setter
+            def optprop(self, value: Optional[int]): pass
+
+        assert len(Meta.get(FooBar)) == 6
+        assert Meta.get(FooBar)['foo'] == Meta("foo", int)
         assert Meta.get(FooBar)['bar'] == Meta("bar", str, optional=True)
-        assert Meta.get(FooBar)['foobar'] == Meta("foobar", list, optional=False)
-        assert Meta.get(FooBar)['barfoo'] == Meta("barfoo", int, optional=False)
+        assert Meta.get(FooBar)['opt'] == Meta("opt", int, optional=True)
+        assert Meta.get(FooBar)['foobar'] == Meta("foobar", list)
+        assert Meta.get(FooBar)['barfoo'] == Meta("barfoo", int)
+        assert Meta.get(FooBar)['optprop'] == Meta("optprop", int, optional=True)
 
     def test_inheritance(self):
         assert len(Meta.get(Base)) == 1
-        assert Meta.get(Base)['foo'] == Meta("foo", int, "some doc", optional=False)
+        assert Meta.get(Base)['foo'] == Meta("foo", int, "some doc")
 
         assert len(Meta.get(Child1)) == 2
-        assert Meta.get(Child1)['foo'] == Meta("foo", int, "some doc", optional=False)
-        assert Meta.get(Child1)['bar'] == Meta("bar", str, "doc b", optional=False)
+        assert Meta.get(Child1)['foo'] == Meta("foo", int, "some doc")
+        assert Meta.get(Child1)['bar'] == Meta("bar", str, "doc b")
 
         assert len(Meta.get(Child2)) == 3
         assert Meta.get(Child2)['foo'] == Meta("foo", str, optional=True)


### PR DESCRIPTION
UBootEnvContent: add content module for creating a U-Boot environment

This allows creating a U-Boot environment in the image, if U-Boot is configured
to load its environment from a region on the sd card/emmc.