### PR TITLE
add support for relocating GPT Partition Table

### DIFF
--- a/embdgen-core/src/embdgen/plugins/label/GPT.py
+++ b/embdgen-core/src/embdgen/plugins/label/GPT.py
@@ -2,6 +2,9 @@
 
 import io
 from pathlib import Path
+import zlib
+import struct
+import math
 
 from embdgen.core.region.BaseRegion import BaseRegion
 from embdgen.core.utils.SizeType import SizeType
@@ -27,10 +30,54 @@ class GPTHeader(BaseRegion):
         self.name = name
         self.is_partition = False
         self.start = SizeType(512)
-        self.size = SizeType(512*33)
+        self.size = SizeType(512)
 
     def write(self, out_file: io.BufferedIOBase):
         return
+
+
+class GPTPartitionTable(BaseRegion):
+
+    backup_table_start: SizeType
+    # A flag to keep track whether the gpt partition table needs be relocated
+    gpt_table_relocated: bool
+
+    def __init__(self, name="GPT Partition Table") -> None:
+        super().__init__()
+        self.name = name
+        self.is_partition = False
+        self.start = SizeType(1024)
+        self.size = SizeType(512*32)
+
+    def write(self, out_file: io.BufferedIOBase) -> None:
+        if self.gpt_table_relocated is True:
+            # change the GPT Table address data in GPT Header
+            out_file.seek(512 + 72)
+            LBAforTable = self.start.sectors
+            out_file.write(struct.pack("I", LBAforTable))
+
+            # Recalculate CRC
+            # Read Header Size
+            out_file.seek(512 + 12)
+            header_size = struct.unpack('I', out_file.read(4))[0]
+
+            # Reset old CRC
+            out_file.seek(512 + 16)
+            out_file.write(struct.pack("I", 0))
+
+            # Read Header and calculate CRC
+            out_file.seek(512)
+            header_data = out_file.read(header_size)
+            crc_header = zlib.crc32(header_data)
+            out_file.seek(512 + 16)
+            out_file.write(struct.pack("I", crc_header))
+
+            # Copy the GPT Partition table from GPT Backup Table
+            out_file.seek(int(self.backup_table_start.bytes))
+            gptTableData = out_file.read(512 * 32)
+            out_file.seek(self.start.bytes)
+            out_file.write(gptTableData)
+
 
 class GPT(BaseLabel):
     """GUID Partition Table (GPT) partition type"""
@@ -40,26 +87,57 @@ class GPT(BaseLabel):
 
     pmbr_header: PMBRHeader
     gpt_header: GPTHeader
+    gpt_table: GPTPartitionTable
     sgpt_header: GPTHeader
+
 
     def __init__(self) -> None:
         super().__init__()
         self.pmbr_header = PMBRHeader()
         self.gpt_header = GPTHeader()
-        self.sgpt_header = GPTHeader("Secondary GPT Header")
+        self.gpt_table = GPTPartitionTable()
+        self.sgpt_header = GPTHeader("Secondary GPT Header and Table")
+        # Size of secondary header is set to header + table again since splitting secondary header is not necessary
+        self.sgpt_header.size = SizeType(512 * 33)
         self.parts.append(self.pmbr_header)
         self.parts.append(self.gpt_header)
+        self.parts.append(self.gpt_table)
+        self.gpt_table.gpt_table_relocated = False
 
-    def prepare(self):
+    def check_for_gpt_relocation (self) -> None:
+        i = 0
+        while i < len(self.parts):
+            if not self.parts[i].start.is_undefined and self.parts[i] != self.gpt_table:
+                if self.parts[i].start < self.gpt_table.start + self.gpt_table.size \
+                    and self.parts[i].start + self.parts[i].size > self.gpt_table.start:
+                    # Locate the GPT Table after this and continue checking
+                    sectorsStart = math.ceil((self.parts[i].start + self.parts[i].size).bytes / 512)
+                    self.gpt_table.start = SizeType(sectorsStart * 512)
+                    self.gpt_table.gpt_table_relocated = True
+                    # The loop is restarted each time a collision is found,
+                    # in case the addresses in the config are not sorted.
+                    i = 0
+            i += 1
+
+        if self.gpt_table.gpt_table_relocated is True:
+            print("The location for the GPT Partition Table is used by another region. Table will be relocated")
+
+
+    def prepare(self) -> None:
         if self.pmbr_header not in self.parts:
             self.parts.append(self.pmbr_header)
         if self.gpt_header not in self.parts:
             self.parts.append(self.gpt_header)
+        if self.gpt_table not in self.parts:
+            self.parts.append(self.gpt_table)
+        self.check_for_gpt_relocation()
+
         super().prepare()
         self.sgpt_header.start = self.parts[-1].start + self.parts[-1].size
         self.parts.append(self.sgpt_header)
+        self.gpt_table.backup_table_start = self.sgpt_header.start
 
-    def create_partition_table(self, filename: Path):
+    def create_partition_table(self, filename: Path) -> None:
         self._create_partition_table(filename, "gpt")
 
     def __repr__(self) -> str:

--- a/embdgen-core/tests/label/test_GPT.py
+++ b/embdgen-core/tests/label/test_GPT.py
@@ -13,6 +13,7 @@ from embdgen.plugins.label.GPT import GPT
 from embdgen.plugins.region.EmptyRegion import EmptyRegion
 from embdgen.plugins.region.PartitionRegion import PartitionRegion
 
+from embdgen.plugins.region.RawRegion import RawRegion
 from embdgen.plugins.content.RawContent import RawContent
 from embdgen.plugins.content.FilesContent import FilesContent
 from embdgen.plugins.content.Fat32Content import Fat32Content
@@ -116,15 +117,213 @@ class TestGPT:
         assert fdisk.regions[0].start_sector == 35
         assert fdisk.regions[1].start_sector == 37
 
-    def test_overlap_primary(self):
+    def test_overlap_GPT_header(self):
         obj = GPT()
 
         empty = EmptyRegion()
         empty.name = "empty region"
-        empty.start = SizeType(512 * 33)
+        empty.start = SizeType(512)
         empty.size = SizeType(512)
 
         obj.parts.append(empty)
 
         with pytest.raises(Exception, match="Part 'empty region' overlapps with 'GPT Header'"):
             obj.prepare()
+
+    def test_overlap_GPT_table(self, tmp_path, capsys: pytest.CaptureFixture[str]):
+        BuildLocation().set_path(tmp_path)
+
+        image = tmp_path / "image"
+        obj = GPT()
+
+        empty = EmptyRegion()
+        empty.name = "empty region"
+        empty.start = SizeType(512 * 2)
+        empty.size = SizeType(512)
+
+        obj.parts.append(empty)
+
+        obj.prepare()
+        obj.create(image)
+
+        fdisk = FdiskParser(image)
+
+        assert fdisk.is_valid
+
+        output = capsys.readouterr().out
+        assert output == "The location for the GPT Partition Table is used by another region. Table will be relocated\n"
+
+    def test_overlap_GPT_table_withParts(self, tmp_path, capsys: pytest.CaptureFixture[str]):
+        BuildLocation().set_path(tmp_path)
+
+        image = tmp_path / "image"
+        obj = GPT()
+
+        empty = EmptyRegion()
+        empty.name = "empty region"
+        empty.start = SizeType(512 * 2)
+        empty.size = SizeType(512)
+
+        ext4_raw = tmp_path / "ext4"
+        ext4_raw.write_bytes(b"1" * 512 * 2)
+        ext4 = PartitionRegion()
+        ext4.fstype = "ext4"
+        ext4.name = "ext4 region"
+        ext4.content = RawContent()
+        ext4.content.file = ext4_raw
+
+        fat32 = PartitionRegion()
+        fat32.fstype = "fat32"
+        fat32.name = "fat32 region"
+        fat32.content = Fat32Content()
+        fat32.content.content = FilesContent()
+        fat32.size = SizeType.parse("5MB")
+
+        obj.parts = [
+            empty,
+            ext4,
+            fat32
+        ]
+        obj.boot_partition = ext4.name
+
+        obj.prepare()
+        obj.create(image)
+
+        fdisk = FdiskParser(image)
+
+        assert fdisk.is_valid
+        assert len(fdisk.regions) == 2
+        assert fdisk.regions[0].start_sector == 35
+        assert fdisk.regions[1].start_sector == 37
+        output = capsys.readouterr().out
+        assert output == "The location for the GPT Partition Table is used by another region. Table will be relocated\n"
+
+
+    def test_overlap_check_data_integrity(self, tmp_path, capsys: pytest.CaptureFixture[str]):
+        BuildLocation().set_path(tmp_path)
+
+        image = tmp_path / "image"
+        obj = GPT()
+
+        rawDataFile = tmp_path / "rawData"
+        rawDataFile.write_bytes(b"TEST" * 512)
+        rawData = RawRegion()
+        rawData.content = RawContent()
+        rawData.content.file = rawDataFile
+        rawData.start = SizeType(512 * 2)
+        rawData.size = SizeType(512 * 4)
+        rawData.name = "RawData"
+
+        obj.parts.append(rawData)
+
+        fat32 = PartitionRegion()
+        fat32.fstype = "fat32"
+        fat32.name = "fat32 region"
+        fat32.content = Fat32Content()
+        fat32.content.content = FilesContent()
+        fat32.size = SizeType.parse("5MB")
+
+        obj.parts.append(fat32)
+
+        obj.prepare()
+        obj.create(image)
+
+        fdisk = FdiskParser(image)
+
+        assert fdisk.is_valid
+        output = image.read_bytes()
+        output_w_offset = output[rawData.start.bytes:rawData.start.bytes + 512 * 4]
+        assert output_w_offset == (b"TEST" * 512)
+        output = capsys.readouterr().out
+        assert output == "The location for the GPT Partition Table is used by another region. Table will be relocated\n"
+
+
+    def test_overlap_unaligned_region(self, tmp_path, capsys: pytest.CaptureFixture[str]):
+        BuildLocation().set_path(tmp_path)
+
+        image = tmp_path / "image"
+        obj = GPT()
+
+        rawDataFile = tmp_path / "rawData"
+        testStrLen = 32
+        rawDataFile.write_bytes(b"TEST" * testStrLen)
+        rawData = RawRegion()
+        rawData.content = RawContent()
+        rawData.content.file = rawDataFile
+        rawData.start = SizeType(512 * 2 + 64)
+        rawData.size = SizeType(testStrLen * 4)
+        rawData.name = "RawData"
+
+        obj.parts.append(rawData)
+
+        fat32 = PartitionRegion()
+        fat32.fstype = "fat32"
+        fat32.name = "fat32 region"
+        fat32.content = Fat32Content()
+        fat32.content.content = FilesContent()
+        fat32.size = SizeType.parse("5MB")
+
+        obj.parts.append(fat32)
+
+        obj.prepare()
+        obj.create(image)
+
+        fdisk = FdiskParser(image)
+
+        assert fdisk.is_valid
+        output = image.read_bytes()
+        output_w_offset = output[rawData.start.bytes : rawData.start.bytes + testStrLen * 4]
+        assert output_w_offset == (b"TEST" * testStrLen)
+        output = capsys.readouterr().out
+        assert output == "The location for the GPT Partition Table is used by another region. Table will be relocated\n"
+
+    def test_overlap_multiRegion(self, tmp_path, capsys: pytest.CaptureFixture[str]):
+        BuildLocation().set_path(tmp_path)
+
+        image = tmp_path / "image"
+        obj = GPT()
+
+        rawDataFile1 = tmp_path / "rawData1"
+        rawDataFile1.write_bytes(b"TEST" * 512)
+        rawData1 = RawRegion()
+        rawData1.content = RawContent()
+        rawData1.content.file = rawDataFile1
+        rawData1.start = SizeType(512 * 2)
+        rawData1.size = SizeType(512 * 4)
+        rawData1.name = "RawData_1"
+
+        obj.parts.append(rawData1)
+
+        rawDataFile2 = tmp_path / "rawData2"
+        rawDataFile2.write_bytes(b"DATA" * 512)
+        rawData2 = RawRegion()
+        rawData2.content = RawContent()
+        rawData2.content.file = rawDataFile2
+        rawData2.start = SizeType(512 * 10)
+        rawData2.size = SizeType(512 * 4)
+        rawData2.name = "RawData_2"
+
+        obj.parts.append(rawData2)
+
+        fat32 = PartitionRegion()
+        fat32.fstype = "fat32"
+        fat32.name = "fat32 region"
+        fat32.content = Fat32Content()
+        fat32.content.content = FilesContent()
+        fat32.size = SizeType.parse("5MB")
+
+        obj.parts.append(fat32)
+
+        obj.prepare()
+        obj.create(image)
+
+        fdisk = FdiskParser(image)
+
+        assert fdisk.is_valid
+        output = image.read_bytes()
+        output_w_offset = output[rawData1.start.bytes : rawData1.start.bytes + 512 * 4]
+        assert output_w_offset == (b"TEST" * 512)
+        output_w_offset_2 = output[rawData2.start.bytes : rawData2.start.bytes + 512 * 4]
+        assert output_w_offset_2 == (b"DATA" * 512)
+        output = capsys.readouterr().out
+        assert output == "The location for the GPT Partition Table is used by another region. Table will be relocated\n"


### PR DESCRIPTION
Added support for relocating GPT Partition Table,
when LBA 2 is used by another region.
GPT Partition Table is moved to the first available empty area automatically.

This happens for example on s32, where the IVT is located in LBA 2.