### PR TITLE
Fix symlink errors

### DIFF
--- a/embdgen-core/src/embdgen/plugins/content/Ext4Content.py
+++ b/embdgen-core/src/embdgen/plugins/content/Ext4Content.py
@@ -1,7 +1,6 @@
 # SPDX-License-Identifier: GPL-3.0-only
 
 import io
-import os
 import shutil
 import subprocess
 from pathlib import Path
@@ -43,9 +42,10 @@ class Ext4Content(BinaryContent):
                 tmp_dir = Path(diro)
                 for file in self.content.files:
                     if file.is_dir():
-                        shutil.copytree(file, Path(tmp_dir) / file.name, dirs_exist_ok=True, copy_function=os.link)
+                        shutil.copytree(file, Path(tmp_dir) / file.name, dirs_exist_ok=True, ignore_dangling_symlinks=True)
                     else:
-                        os.link(str(file), str(Path(tmp_dir) / file.name))
+                        shutil.copyfile(str(file), str(Path(tmp_dir) / file.name))
+
 
                 FakeRoot(get_temp_file(), self.content.fakeroot).run([
                     "mkfs.ext4",


### PR DESCRIPTION
This PR fixes two issues:

- cross-device symlink error
- dangling symlinks error

When the archive is on a different partition than the default location for temporary directories, the build fails with a cross-device link error:

```bash
Preparing...
 
The final layout:
MBR:
  0x000001b8 - 0x00000200 Part MBR Header
  0x00000200 - 0x06400200 Part boot
    Fat32Content()
  0x06400200 - 0x86400200 Part root
    Ext4Content(ArchiveContent(files/archive.tar))
 
Writing image to image.raw
Traceback (most recent call last):
  File "/build/venv/bin/embdgen", line 8, in <module>
    sys.exit(cli())
  File "/build/embdgen/embdgen-core/src/embdgen/core/cli/__init__.py", line 7, in cli
    CLI().run(args)
  File "/build/embdgen/embdgen-core/src/embdgen/core/cli/CLI.py", line 65, in run
    label.create(options.output)
  File "/build/embdgen/embdgen-core/src/embdgen/core/label/BaseLabel.py", line 131, in create
    part.write(f)
  File "/build/embdgen/embdgen-core/src/embdgen/plugins/region/PartitionRegion.py", line 26, in write
    self.content.write(out_file)
  File "/build/embdgen/embdgen-core/src/embdgen/core/content/BinaryContent.py", line 32, in write
    self.do_write(file)
  File "/build/embdgen/embdgen-core/src/embdgen/plugins/content/Ext4Content.py", line 61, in do_write
    with open(self.result_file, "rb") as in_file:
  File "/build/embdgen/embdgen-core/src/embdgen/core/content/BinaryContent.py", line 24, in result_file
    self._prepare_result()
  File "/build/embdgen/embdgen-core/src/embdgen/plugins/content/Ext4Content.py", line 46, in _prepare_result
    shutil.copytree(file, Path(tmp_dir) / file.name, dirs_exist_ok=True, copy_function=os.link)
  File "/usr/lib/python3.10/shutil.py", line 559, in copytree
    return _copytree(entries=entries, src=src, dst=dst, symlinks=symlinks,
  File "/usr/lib/python3.10/shutil.py", line 513, in _copytree
    raise Error(errors)
shutil.Error: [('/tmp/embdgen-nigdh4ic/tmpiyd3q103/run/shm/libpod_lock', '/tmp/embdgen-nigdh4ic/tmp9aw541i2/run/shm/libpod_lock', "[Errno 18] Invalid cross-device link: '/tmp/embdgen-nigdh4ic/tmpiyd3q103/run/shm/libpod_lock' -> '/tmp/embdgen-nigdh4ic/tmp9aw541i2/run/shm/libpod_lock'")]
```

Dangling symlink:

```bash
Preparing...

The final layout:
MBR:
  0x000001b8 - 0x00000200 Part MBR Header
  0x00000200 - 0x06400200 Part boot
    Fat32Content()
  0x06400200 - 0x86400200 Part root
    Ext4Content(ArchiveContent(files/ubuntu.tar))

Writing image to image.raw
Traceback (most recent call last):
  File "/build/venv/bin/embdgen", line 8, in <module>
    sys.exit(cli())
  File "/build/embdgen/embdgen-core/src/embdgen/core/cli/__init__.py", line 7, in cli
    CLI().run(args)
  File "/build/embdgen/embdgen-core/src/embdgen/core/cli/CLI.py", line 65, in run
    label.create(options.output)
  File "/build/embdgen/embdgen-core/src/embdgen/core/label/BaseLabel.py", line 131, in create
    part.write(f)
  File "/build/embdgen/embdgen-core/src/embdgen/plugins/region/PartitionRegion.py", line 26, in write
    self.content.write(out_file)
  File "/build/embdgen/embdgen-core/src/embdgen/core/content/BinaryContent.py", line 32, in write
    self.do_write(file)
  File "/build/embdgen/embdgen-core/src/embdgen/plugins/content/Ext4Content.py", line 61, in do_write
    with open(self.result_file, "rb") as in_file:
  File "/build/embdgen/embdgen-core/src/embdgen/core/content/BinaryContent.py", line 24, in result_file
    self._prepare_result()
  File "/build/embdgen/embdgen-core/src/embdgen/plugins/content/Ext4Content.py", line 46, in _prepare_result
    shutil.copytree(file, Path(tmp_dir) / file.name, dirs_exist_ok=True)
  File "/usr/lib/python3.10/shutil.py", line 559, in copytree
    return _copytree(entries=entries, src=src, dst=dst, symlinks=symlinks,
  File "/usr/lib/python3.10/shutil.py", line 513, in _copytree
    raise Error(errors)
shutil.Error: [('/workspace/images/embegen/raspberry-pi/tmp/tmpwhfoj_7i/usr/share/doc/base-files/FAQ', '/workspace/images/embegen/raspberry-pi/tmp/tmpuwdo2524/usr/share/doc/base-files/FAQ', "[Errno 2] No such file or directory: '/workspace/images/embegen/raspberry-pi/tmp/tmpwhfoj_7i/usr/share/doc/base-files/FAQ'"), ('/workspace/images/embegen/raspberry-pi/tmp/tmpwhfoj_7i/usr/share/doc/procps/NEWS.Debian.gz', '/workspace/images/embegen/raspberry-pi/tmp/tmpuwdo2524/usr/share/doc/procps/NEWS.Debian.gz', "[Errno 2] No such file or directory: '/workspace/images/embegen/raspberry-pi/tmp/tmpwhfoj_7i/usr/share/doc/procps/NEWS.Debian.gz'"), ('/workspace/images/embegen/raspberry-pi/tmp/tmpwhfoj_7i/usr/share/doc/apt/NEWS.Debian.gz', '/workspace/images/embegen/raspberry-pi/tmp/tmpuwdo2524/usr/share/doc/apt/NEWS.Debian.gz', "[Errno 2] No such file or directory: '/workspace/images/embegen/raspberry-pi/tmp/tmpwhfoj_7i/usr/share/doc/apt/NEWS.Debian.gz'"), ('/workspace/images/embegen/raspberry-pi/tmp/tmpwhfoj_7i/usr/share/locale/gl/LC_TIME/coreutils.mo', '/workspace/images/embegen/raspberry-pi/tmp/tmpuwdo2524/usr/share/locale/gl/LC_TIME/coreutils.mo', "[Errno 2] No such file or directory: '/workspace/images/embegen/raspberry-pi/tmp/tmpwhfoj_7i/usr/share/locale/gl/LC_TIME/coreutils.mo'"), ('/workspace/images/embegen/raspberry-pi/tmp/tmpwhfoj_7i/usr/share/locale/ka/LC_TIME/coreutils.mo', '/workspace/images/embegen/raspberry-pi/tmp/tmpuwdo2524/usr/share/locale/ka/LC_TIME/coreutils.mo', "[Errno 2] No such file or directory: '/workspace/images/embegen/raspberry-pi/tmp/tmpwhfoj_7i/usr/share/locale/ka/LC_TIME/coreutils.mo'"), ('/workspace/images/embegen/raspberry-pi/tmp/tmpwhfoj_7i/usr/share/locale/hu/LC_TIME/coreutils.mo', '/workspace/images/embegen/raspberry-pi/tmp/tmpuwdo2524/usr/share/locale/hu/LC_TIME/coreutils.mo', "[Errno 2] No such file or directory: '/workspace/images/embegen/raspberry-pi/tmp/tmpwhfoj_7i/usr/share/locale/hu/LC_TIME/coreutils.mo'"), ('/workspace/images/embegen/raspberry-pi/tmp/tmpwhfoj_7i/usr/share/locale/sl/LC_TIME/coreutils.mo', '/workspace/images/embegen/raspberry-pi/tmp/tmpuwdo2524/usr/share/locale/sl/LC_TIME/coreutils.mo', "[Errno 2] No such file or directory: '/workspace/images/embegen/raspberry-pi/tmp/tmpwhfoj_7i/usr/share/locale/sl/LC_TIME/coreutils.mo'"), ('/workspace/images/embegen/raspberry-pi/tmp/tmpwhfoj_7i/usr/share/locale/cs/LC_TIME/coreutils.mo', '/workspace/images/embegen/raspberry-pi/tmp/tmpuwdo2524/usr/share/locale/cs/LC_TIME/coreutils.mo', "[Errno 2] No such file or directory: '/workspace/images/embegen/raspberry-pi/tmp/tmpwhfoj_7i/usr/share/locale/cs/LC_TIME/coreutils.mo'"), ('/workspace/images/embegen/raspberry-pi/tmp/tmpwhfoj_7i/usr/share/locale/ja/LC_TIME/coreutils.mo', '/workspace/images/embegen/raspberry-pi/tmp/tmpuwdo2524/usr/share/locale/ja/LC_TIME/coreutils.mo', "[Errno 2] No such file or directory: '/workspace/images/embegen/raspberry-pi/tmp/tmpwhfoj_7i/usr/share/locale/ja/LC_TIME/coreutils.mo'"), ('/workspace/images/embegen/raspberry-pi/tmp/tmpwhfoj_7i/usr/share/locale/sv/LC_TIME/coreutils.mo', '/workspace/images/embegen/raspberry-pi/tmp/tmpuwdo2524/usr/share/locale/sv/LC_TIME/coreutils.mo', "[Errno 2] No such file or directory: '/workspace/images/embegen/raspberry-pi/tmp/tmpwhfoj_7i/usr/share/locale/sv/LC_TIME/coreutils.mo'"), ('/workspace/images/embegen/raspberry-pi/tmp/tmpwhfoj_7i/usr/share/locale/zh_CN/LC_TIME/coreutils.mo', '/workspace/images/embegen/raspberry-pi/tmp/tmpuwdo2524/usr/share/locale/zh_CN/LC_TIME/coreutils.mo', "[Errno 2] No such file or directory: '/workspace/images/embegen/raspberry-pi/tmp/tmpwhfoj_7i/usr/share/locale/zh_CN/LC_TIME/coreutils.mo'"), ('/workspace/images/embegen/raspberry-pi/tmp/tmpwhfoj_7i/usr/share/locale/es/LC_TIME/coreutils.mo', '/workspace/images/embegen/raspberry-pi/tmp/tmpuwdo2524/usr/share/locale/es/LC_TIME/coreutils.mo', "[Errno 2] No such file or directory: '/workspace/images/embegen/raspberry-pi/tmp/tmpwhfoj_7i/usr/share/locale/es/LC_TIME/coreutils.mo'"), ('/workspace/images/embegen/raspberry-pi/tmp/tmpwhfoj_7i/usr/share/locale/ru/LC_TIME/coreutils.mo', '/workspace/images/embegen/raspberry-pi/tmp/tmpuwdo2524/usr/share/locale/ru/LC_TIME/coreutils.mo', "[Errno 2] No such file or directory: '/workspace/images/embegen/raspberry-pi/tmp/tmpwhfoj_7i/usr/share/locale/ru/LC_TIME/coreutils.mo'"), ('/workspace/images/embegen/raspberry-pi/tmp/tmpwhfoj_7i/usr/share/locale/bg/LC_TIME/coreutils.mo', '/workspace/images/embegen/raspberry-pi/tmp/tmpuwdo2524/usr/share/locale/bg/LC_TIME/coreutils.mo', "[Errno 2] No such file or directory: '/workspace/images/embegen/raspberry-pi/tmp/tmpwhfoj_7i/usr/share/locale/bg/LC_TIME/coreutils.mo'"), ('/workspace/images/embegen/raspberry-pi/tmp/tmpwhfoj_7i/usr/share/locale/kk/LC_TIME/coreutils.mo', '/workspace/images/embegen/raspberry-pi/tmp/tmpuwdo2524/usr/share/locale/kk/LC_TIME/coreutils.mo', "[Errno 2] No such file or directory: '/workspace/images/embegen/raspberry-pi/tmp/tmpwhfoj_7i/usr/share/locale/kk/LC_TIME/coreutils.mo'"), ('/workspace/images/embegen/raspberry-pi/tmp/tmpwhfoj_7i/usr/share/locale/eu/LC_TIME/coreutils.mo', '/workspace/images/embegen/raspberry-pi/tmp/tmpuwdo2524/usr/share/locale/eu/LC_TIME/coreutils.mo', "[Errno 2] No such file or directory: '/workspace/images/embegen/raspberry-pi/tmp/tmpwhfoj_7i/usr/share/locale/eu/LC_TIME/coreutils.mo'"), ('/workspace/images/embegen/raspberry-pi/tmp/tmpwhfoj_7i/usr/share/locale/ms/LC_TIME/coreutils.mo', '/workspace/images/embegen/raspberry-pi/tmp/tmpuwdo2524/usr/share/locale/ms/LC_TIME/coreutils.mo', "[Errno 2] No such file or directory: '/workspace/images/embegen/raspberry-pi/tmp/tmpwhfoj_7i/usr/share/locale/ms/LC_TIME/coreutils.mo'"), ('/workspace/images/embegen/raspberry-pi/tmp/tmpwhfoj_7i/usr/share/locale/it/LC_TIME/coreutils.mo', '/workspace/images/embegen/raspberry-pi/tmp/tmpuwdo2524/usr/share/locale/it/LC_TIME/coreutils.mo', "[Errno 2] No such file or directory: '/workspace/images/embegen/raspberry-pi/tmp/tmpwhfoj_7i/usr/share/locale/it/LC_TIME/coreutils.mo'"), ('/workspace/images/embegen/raspberry-pi/tmp/tmpwhfoj_7i/usr/share/locale/sk/LC_TIME/coreutils.mo', '/workspace/images/embegen/raspberry-pi/tmp/tmpuwdo2524/usr/share/locale/sk/LC_TIME/coreutils.mo', "[Errno 2] No such file or directory: '/workspace/images/embegen/raspberry-pi/tmp/tmpwhfoj_7i/usr/share/locale/sk/LC_TIME/coreutils.mo'"), ('/workspace/images/embegen/raspberry-pi/tmp/tmpwhfoj_7i/usr/share/locale/et/LC_TIME/coreutils.mo', '/workspace/images/embegen/raspberry-pi/tmp/tmpuwdo2524/usr/share/locale/et/LC_TIME/coreutils.mo', "[Errno 2] No such file or directory: '/workspace/images/embegen/raspberry-pi/tmp/tmpwhfoj_7i/usr/share/locale/et/LC_TIME/coreutils.mo'"), ('/workspace/images/embegen/raspberry-pi/tmp/tmpwhfoj_7i/usr/share/locale/ia/LC_TIME/coreutils.mo', '/workspace/images/embegen/raspberry-pi/tmp/tmpuwdo2524/usr/share/locale/ia/LC_TIME/coreutils.mo', "[Errno 2] No such file or directory: '/workspace/images/embegen/raspberry-pi/tmp/tmpwhfoj_7i/usr/share/locale/ia/LC_TIME/coreutils.mo'"), ('/workspace/images/embegen/raspberry-pi/tmp/tmpwhfoj_7i/usr/share/locale/ro/LC_TIME/coreutils.mo', '/workspace/images/embegen/raspberry-pi/tmp/tmpuwdo2524/usr/share/locale/ro/LC_TIME/coreutils.mo', "[Errno 2] No such file or directory: '/workspace/images/embegen/raspberry-pi/tmp/tmpwhfoj_7i/usr/share/locale/ro/LC_TIME/coreutils.mo'"), ('/workspace/images/embegen/raspberry-pi/tmp/tmpwhfoj_7i/usr/share/locale/hr/LC_TIME/coreutils.mo', '/workspace/images/embegen/raspberry-pi/tmp/tmpuwdo2524/usr/share/locale/hr/LC_TIME/coreutils.mo', "[Errno 2] No such file or directory: '/workspace/images/embegen/raspberry-pi/tmp/tmpwhfoj_7i/usr/share/locale/hr/LC_TIME/coreutils.mo'"), ('/workspace/images/embegen/raspberry-pi/tmp/tmpwhfoj_7i/usr/share/locale/pl/LC_TIME/coreutils.mo', '/workspace/images/embegen/raspberry-pi/tmp/tmpuwdo2524/usr/share/locale/pl/LC_TIME/coreutils.mo', "[Errno 2] No such file or directory: '/workspace/images/embegen/raspberry-pi/tmp/tmpwhfoj_7i/usr/share/locale/pl/LC_TIME/coreutils.mo'"), ('/workspace/images/embegen/raspberry-pi/tmp/tmpwhfoj_7i/usr/share/locale/fi/LC_TIME/coreutils.mo', '/workspace/images/embegen/raspberry-pi/tmp/tmpuwdo2524/usr/share/locale/fi/LC_TIME/coreutils.mo', "[Errno 2] No such file or directory: '/workspace/images/embegen/raspberry-pi/tmp/tmpwhfoj_7i/usr/share/locale/fi/LC_TIME/coreutils.mo'"), ('/workspace/images/embegen/raspberry-pi/tmp/tmpwhfoj_7i/usr/share/locale/id/LC_TIME/coreutils.mo', '/workspace/images/embegen/raspberry-pi/tmp/tmpuwdo2524/usr/share/locale/id/LC_TIME/coreutils.mo', "[Errno 2] No such file or directory: '/workspace/images/embegen/raspberry-pi/tmp/tmpwhfoj_7i/usr/share/locale/id/LC_TIME/coreutils.mo'"), ('/workspace/images/embegen/raspberry-pi/tmp/tmpwhfoj_7i/usr/share/locale/zh_TW/LC_TIME/coreutils.mo', '/workspace/images/embegen/raspberry-pi/tmp/tmpuwdo2524/usr/share/locale/zh_TW/LC_TIME/coreutils.mo', "[Errno 2] No such file or directory: '/workspace/images/embegen/raspberry-pi/tmp/tmpwhfoj_7i/usr/share/locale/zh_TW/LC_TIME/coreutils.mo'"), ('/workspace/images/embegen/raspberry-pi/tmp/tmpwhfoj_7i/usr/share/locale/uk/LC_TIME/coreutils.mo', '/workspace/images/embegen/raspberry-pi/tmp/tmpuwdo2524/usr/share/locale/uk/LC_TIME/coreutils.mo', "[Errno 2] No such file or directory: '/workspace/images/embegen/raspberry-pi/tmp/tmpwhfoj_7i/usr/share/locale/uk/LC_TIME/coreutils.mo'"), ('/workspace/images/embegen/raspberry-pi/tmp/tmpwhfoj_7i/usr/share/locale/ko/LC_TIME/coreutils.mo', '/workspace/images/embegen/raspberry-pi/tmp/tmpuwdo2524/usr/share/locale/ko/LC_TIME/coreutils.mo', "[Errno 2] No such file or directory: '/workspace/images/embegen/raspberry-pi/tmp/tmpwhfoj_7i/usr/share/locale/ko/LC_TIME/coreutils.mo'"), ('/workspace/images/embegen/raspberry-pi/tmp/tmpwhfoj_7i/usr/share/locale/da/LC_TIME/coreutils.mo', '/workspace/images/embegen/raspberry-pi/tmp/tmpuwdo2524/usr/share/locale/da/LC_TIME/coreutils.mo', "[Errno 2] No such file or directory: '/workspace/images/embegen/raspberry-pi/tmp/tmpwhfoj_7i/usr/share/locale/da/LC_TIME/coreutils.mo'"), ('/workspace/images/embegen/raspberry-pi/tmp/tmpwhfoj_7i/usr/share/locale/sr/LC_TIME/coreutils.mo', '/workspace/images/embegen/raspberry-pi/tmp/tmpuwdo2524/usr/share/locale/sr/LC_TIME/coreutils.mo', "[Errno 2] No such file or directory: '/workspace/images/embegen/raspberry-pi/tmp/tmpwhfoj_7i/usr/share/locale/sr/LC_TIME/coreutils.mo'"), ('/workspace/images/embegen/raspberry-pi/tmp/tmpwhfoj_7i/usr/share/locale/tr/LC_TIME/coreutils.mo', '/workspace/images/embegen/raspberry-pi/tmp/tmpuwdo2524/usr/share/locale/tr/LC_TIME/coreutils.mo', "[Errno 2] No such file or directory: '/workspace/images/embegen/raspberry-pi/tmp/tmpwhfoj_7i/usr/share/locale/tr/LC_TIME/coreutils.mo'"), ('/workspace/images/embegen/raspberry-pi/tmp/tmpwhfoj_7i/usr/share/locale/ca/LC_TIME/coreutils.mo', '/workspace/images/embegen/raspberry-pi/tmp/tmpuwdo2524/usr/share/locale/ca/LC_TIME/coreutils.mo', "[Errno 2] No such file or directory: '/workspace/images/embegen/raspberry-pi/tmp/tmpwhfoj_7i/usr/share/locale/ca/LC_TIME/coreutils.mo'"), ('/workspace/images/embegen/raspberry-pi/tmp/tmpwhfoj_7i/usr/share/locale/vi/LC_TIME/coreutils.mo', '/workspace/images/embegen/raspberry-pi/tmp/tmpuwdo2524/usr/share/locale/vi/LC_TIME/coreutils.mo', "[Errno 2] No such file or directory: '/workspace/images/embegen/raspberry-pi/tmp/tmpwhfoj_7i/usr/share/locale/vi/LC_TIME/coreutils.mo'"), ('/workspace/images/embegen/raspberry-pi/tmp/tmpwhfoj_7i/usr/share/locale/pt/LC_TIME/coreutils.mo', '/workspace/images/embegen/raspberry-pi/tmp/tmpuwdo2524/usr/share/locale/pt/LC_TIME/coreutils.mo', "[Errno 2] No such file or directory: '/workspace/images/embegen/raspberry-pi/tmp/tmpwhfoj_7i/usr/share/locale/pt/LC_TIME/coreutils.mo'"), ('/workspace/images/embegen/raspberry-pi/tmp/tmpwhfoj_7i/usr/share/locale/be/LC_TIME/coreutils.mo', '/workspace/images/embegen/raspberry-pi/tmp/tmpuwdo2524/usr/share/locale/be/LC_TIME/coreutils.mo', "[Errno 2] No such file or directory: '/workspace/images/embegen/raspberry-pi/tmp/tmpwhfoj_7i/usr/share/locale/be/LC_TIME/coreutils.mo'"), ('/workspace/images/embegen/raspberry-pi/tmp/tmpwhfoj_7i/usr/share/locale/el/LC_TIME/coreutils.mo', '/workspace/images/embegen/raspberry-pi/tmp/tmpuwdo2524/usr/share/locale/el/LC_TIME/coreutils.mo', "[Errno 2] No such file or directory: '/workspace/images/embegen/raspberry-pi/tmp/tmpwhfoj_7i/usr/share/locale/el/LC_TIME/coreutils.mo'"), ('/workspace/images/embegen/raspberry-pi/tmp/tmpwhfoj_7i/usr/share/locale/pt_BR/LC_TIME/coreutils.mo', '/workspace/images/embegen/raspberry-pi/tmp/tmpuwdo2524/usr/share/locale/pt_BR/LC_TIME/coreutils.mo', "[Errno 2] No such file or directory: '/workspace/images/embegen/raspberry-pi/tmp/tmpwhfoj_7i/usr/share/locale/pt_BR/LC_TIME/coreutils.mo'"), ('/workspace/images/embegen/raspberry-pi/tmp/tmpwhfoj_7i/usr/share/locale/de/LC_TIME/coreutils.mo', '/workspace/images/embegen/raspberry-pi/tmp/tmpuwdo2524/usr/share/locale/de/LC_TIME/coreutils.mo', "[Errno 2] No such file or directory: '/workspace/images/embegen/raspberry-pi/tmp/tmpwhfoj_7i/usr/share/locale/de/LC_TIME/coreutils.mo'"), ('/workspace/images/embegen/raspberry-pi/tmp/tmpwhfoj_7i/usr/share/locale/nb/LC_TIME/coreutils.mo', '/workspace/images/embegen/raspberry-pi/tmp/tmpuwdo2524/usr/share/locale/nb/LC_TIME/coreutils.mo', "[Errno 2] No such file or directory: '/workspace/images/embegen/raspberry-pi/tmp/tmpwhfoj_7i/usr/share/locale/nb/LC_TIME/coreutils.mo'"), ('/workspace/images/embegen/raspberry-pi/tmp/tmpwhfoj_7i/usr/share/locale/fr/LC_TIME/coreutils.mo', '/workspace/images/embegen/raspberry-pi/tmp/tmpuwdo2524/usr/share/locale/fr/LC_TIME/coreutils.mo', "[Errno 2] No such file or directory: '/workspace/images/embegen/raspberry-pi/tmp/tmpwhfoj_7i/usr/share/locale/fr/LC_TIME/coreutils.mo'"), ('/workspace/images/embegen/raspberry-pi/tmp/tmpwhfoj_7i/usr/share/locale/nl/LC_TIME/coreutils.mo', '/workspace/images/embegen/raspberry-pi/tmp/tmpuwdo2524/usr/share/locale/nl/LC_TIME/coreutils.mo', "[Errno 2] No such file or directory: '/workspace/images/embegen/raspberry-pi/tmp/tmpwhfoj_7i/usr/share/locale/nl/LC_TIME/coreutils.mo'"), ('/workspace/images/embegen/raspberry-pi/tmp/tmpwhfoj_7i/usr/share/locale/lg/LC_TIME/coreutils.mo', '/workspace/images/embegen/raspberry-pi/tmp/tmpuwdo2524/usr/share/locale/lg/LC_TIME/coreutils.mo', "[Errno 2] No such file or directory: '/workspace/images/embegen/raspberry-pi/tmp/tmpwhfoj_7i/usr/share/locale/lg/LC_TIME/coreutils.mo'"), ('/workspace/images/embegen/raspberry-pi/tmp/tmpwhfoj_7i/usr/share/locale/eo/LC_TIME/coreutils.mo', '/workspace/images/embegen/raspberry-pi/tmp/tmpuwdo2524/usr/share/locale/eo/LC_TIME/coreutils.mo', "[Errno 2] No such file or directory: '/workspace/images/embegen/raspberry-pi/tmp/tmpwhfoj_7i/usr/share/locale/eo/LC_TIME/coreutils.mo'"), ('/workspace/images/embegen/raspberry-pi/tmp/tmpwhfoj_7i/usr/share/locale/lt/LC_TIME/coreutils.mo', '/workspace/images/embegen/raspberry-pi/tmp/tmpuwdo2524/usr/share/locale/lt/LC_TIME/coreutils.mo', "[Errno 2] No such file or directory: '/workspace/images/embegen/raspberry-pi/tmp/tmpwhfoj_7i/usr/share/locale/lt/LC_TIME/coreutils.mo'"), ('/workspace/images/embegen/raspberry-pi/tmp/tmpwhfoj_7i/usr/share/locale/ga/LC_TIME/coreutils.mo', '/workspace/images/embegen/raspberry-pi/tmp/tmpuwdo2524/usr/share/locale/ga/LC_TIME/coreutils.mo', "[Errno 2] No such file or directory: '/workspace/images/embegen/raspberry-pi/tmp/tmpwhfoj_7i/usr/share/locale/ga/LC_TIME/coreutils.mo'"), ('/workspace/images/embegen/raspberry-pi/tmp/tmpwhfoj_7i/usr/share/locale/af/LC_TIME/coreutils.mo', '/workspace/images/embegen/raspberry-pi/tmp/tmpuwdo2524/usr/share/locale/af/LC_TIME/coreutils.mo', "[Errno 2] No such file or directory: '/workspace/images/embegen/raspberry-pi/tmp/tmpwhfoj_7i/usr/share/locale/af/LC_TIME/coreutils.mo'"), ('/workspace/images/embegen/raspberry-pi/tmp/tmpwhfoj_7i/usr/share/locale/ta/LC_TIME/coreutils.mo', '/workspace/images/embegen/raspberry-pi/tmp/tmpuwdo2524/usr/share/locale/ta/LC_TIME/coreutils.mo', "[Errno 2] No such file or directory: '/workspace/images/embegen/raspberry-pi/tmp/tmpwhfoj_7i/usr/share/locale/ta/LC_TIME/coreutils.mo'")]
```
