### PR TITLE
Fix ext4

### DIFF
--- a/embdgen-core/src/embdgen/core/utils/FakeRoot.py
+++ b/embdgen-core/src/embdgen/core/utils/FakeRoot.py
@@ -1,14 +1,18 @@
 # SPDX-License-Identifier: GPL-3.0-only
 
+from collections import deque
+import os
 from pathlib import Path
 import shutil
+import stat
 import subprocess
-from typing import Optional, List, Union
+import sys
+from typing import Deque, Iterable, Optional, Tuple, List, Union
 
 
 class FakeRoot():
     """Encapsulate usage of fakeroot command line tool
-    
+
     This allows file operations, that are usually only possible with root rights
     (e.g setting owner/group and creating device nodes).
     The files are created on the filesystem just like normal files and the attributes,
@@ -56,3 +60,69 @@ class FakeRoot():
             "--",
             *args
         ], check=check, **kwargs)
+
+
+    def copy(self, src: Path, dest: Path)-> None:
+        """
+        Copy a file or a directory tree from src to dest.
+
+        dest is always a directory and created if it does not exist.
+        The copying is done under fakeroot, to preserve all attributes.
+        Symlinks in src (or if src is a symlink) are preserved in dest with
+        the same target.
+        Files are either hardlinked, if possible, or copied.
+        """
+        mod_self = sys.modules[__name__].__spec__
+        if not mod_self: # pragma: no cover
+            raise Exception("Cannot determine the module name of FakeRoot")
+        dest.mkdir(parents=True, exist_ok=True)
+        self.run([
+            sys.executable,
+            "-m", mod_self.name,
+            src, dest
+        ])
+
+def copy_recursive(src_: Path, dest_: Path):
+    to_do: Deque[Tuple[Iterable[Path], Path]] = deque([([src_], dest_)])
+
+    def copy_attrs(src: Path, dest: Path, sstat: os.stat_result) -> None:
+        shutil.copystat(src, dest)
+        os.chown(dest, sstat.st_uid, sstat.st_gid)
+
+    while to_do:
+        srcs, dest_root = to_do.popleft()
+        for src in srcs:
+            dest = dest_root / src.name
+            sstat: os.stat_result = src.lstat()
+
+            if stat.S_ISLNK(sstat.st_mode):
+                dest.symlink_to(src.readlink())
+            elif stat.S_ISDIR(sstat.st_mode):
+                dest.mkdir(exist_ok=True)
+                copy_attrs(src, dest, sstat)
+                to_do.append((list(src.iterdir()), dest))
+            elif stat.S_ISCHR(sstat.st_mode) or stat.S_ISBLK(sstat.st_mode) or stat.S_ISFIFO(sstat.st_mode):
+                os.mknod(dest, sstat.st_mode, sstat.st_rdev)
+                copy_attrs(src, dest, sstat)
+            elif stat.S_ISREG(sstat.st_mode):
+                try:
+                    os.link(src, dest)
+                except OSError:
+                    # Fallback to copy, if hardlink does not work
+                    shutil.copyfile(src, dest)
+                    copy_attrs(src, dest, sstat)
+            else: # pragma: no cover
+                raise Exception(f"Unable to copy {src}, unknown file type: {sstat.st_mode}")
+
+def copy_main() -> int:
+    if len(sys.argv) != 3: # pragma: no cover
+        print("invalid arg count:", sys.argv)
+        return 1
+
+    src = Path(sys.argv[1])
+    dest = Path(sys.argv[2])
+    copy_recursive(src, dest)
+    return 0
+
+if __name__ == "__main__":
+    sys.exit(copy_main())

--- a/embdgen-core/src/embdgen/plugins/content/Ext4Content.py
+++ b/embdgen-core/src/embdgen/plugins/content/Ext4Content.py
@@ -15,6 +15,7 @@ from embdgen.core.utils.image import (BuildLocation, copy_sparse,
 
 
 @Config("content")
+@Config("size", optional=True)
 class Ext4Content(BinaryContent):
     """Ext4 Content
     """

--- a/embdgen-core/src/embdgen/plugins/content/Ext4Content.py
+++ b/embdgen-core/src/embdgen/plugins/content/Ext4Content.py
@@ -1,10 +1,8 @@
 # SPDX-License-Identifier: GPL-3.0-only
 
 import io
-import os
-import shutil
-import subprocess
 from pathlib import Path
+import subprocess
 from tempfile import TemporaryDirectory
 from typing import Optional
 
@@ -40,14 +38,12 @@ class Ext4Content(BinaryContent):
 
         if self.content:
             with TemporaryDirectory(dir=BuildLocation().path) as diro:
+                fr = FakeRoot(get_temp_file(), self.content.fakeroot)
                 tmp_dir = Path(diro)
                 for file in self.content.files:
-                    if file.is_dir():
-                        shutil.copytree(file, Path(tmp_dir) / file.name, dirs_exist_ok=True, copy_function=os.link)
-                    else:
-                        os.link(str(file), str(Path(tmp_dir) / file.name))
+                    fr.copy(file, tmp_dir)
 
-                FakeRoot(get_temp_file(), self.content.fakeroot).run([
+                fr.run([
                     "mkfs.ext4",
                     "-d", diro,
                     self.result_file

--- a/embdgen-core/src/embdgen/plugins/content/Fat32Content.py
+++ b/embdgen-core/src/embdgen/plugins/content/Fat32Content.py
@@ -11,6 +11,7 @@ from embdgen.core.utils.image import copy_sparse, create_empty_image
 
 
 @Config("content")
+@Config("size", optional=True)
 class Fat32Content(BinaryContent):
     """Fat32 Content
 
@@ -29,7 +30,7 @@ class Fat32Content(BinaryContent):
 
     def prepare(self) -> None:
         if self.size.is_undefined:
-            raise Exception("Fat32 regions require a fixed size at the moment")
+            raise Exception("Fat32 content requires a fixed size at the moment")
         if self.content:
             self.content.prepare()
 

--- a/embdgen-core/tests/content/test_ArchiveContent.py
+++ b/embdgen-core/tests/content/test_ArchiveContent.py
@@ -1,6 +1,5 @@
 # SPDX-License-Identifier: GPL-3.0-only
 
-from functools import lru_cache
 import os
 from pathlib import Path
 import subprocess
@@ -9,15 +8,7 @@ from embdgen.plugins.content.ArchiveContent import ArchiveContent  # type: ignor
 from embdgen.core.utils.image import BuildLocation
 from embdgen.core.utils.FakeRoot import FakeRoot
 
-@lru_cache
-def cur_umask() -> int:
-    tmp = os.umask(0o022)
-    os.umask(tmp)
-    return tmp
-
-def calc_umask(mode: int) -> str:
-    mode = mode & ~cur_umask()
-    return f"{mode:o}"
+from ..test_utils.system import calc_umask
 
 def test_simple(tmp_path: Path):
     BuildLocation().set_path(tmp_path)
@@ -108,7 +99,7 @@ def test_fakeroot(tmp_path: Path):
 
     assert files == [
         ['a',    '123', '456', '777', '0',   '0'],
-        ['bar',  uid,   gid,   calc_umask(0o777), '0',   '0'],
-        ['foo',  uid,   gid,   calc_umask(0o666), '0',   '0'],
-        ['node', '0',   '0',   calc_umask(0o666), '123', '456']
+        ['bar',  uid,   gid,   f"{calc_umask(0o777):o}", '0',   '0'],
+        ['foo',  uid,   gid,   f"{calc_umask(0o666):o}", '0',   '0'],
+        ['node', '0',   '0',   f"{calc_umask(0o666):o}", '123', '456']
     ]

--- a/embdgen-core/tests/content/test_Fat32Content.py
+++ b/embdgen-core/tests/content/test_Fat32Content.py
@@ -46,7 +46,7 @@ class TestFat32Content:
         obj.content = FilesContent()
         obj.content.files = test_files
 
-        with pytest.raises(Exception, match="Fat32 regions require a fixed size at the moment"):
+        with pytest.raises(Exception, match="Fat32 content requires a fixed size at the moment"):
             obj.prepare()
         assert obj.size.is_undefined
 

--- a/embdgen-core/tests/test_utils/system.py
+++ b/embdgen-core/tests/test_utils/system.py
@@ -1,0 +1,11 @@
+from functools import lru_cache
+import os
+
+@lru_cache
+def cur_umask() -> int:
+    tmp = os.umask(0o022)
+    os.umask(tmp)
+    return tmp
+
+def calc_umask(mode: int) -> int:
+    return mode & ~cur_umask()

--- a/embdgen-core/tests/utils/test_FakeRoot.py
+++ b/embdgen-core/tests/utils/test_FakeRoot.py
@@ -3,15 +3,51 @@
 import os
 from pathlib import Path
 import pytest
+import stat
 
 from embdgen.core.utils.FakeRoot import FakeRoot, subprocess
 
+from ..test_utils.system import calc_umask
+
 def get_uid_and_gid(fr: FakeRoot, file: Path) -> str:
+    if not fr:
+        fr = subprocess
     res = fr.run([
         "stat",
         "-c", "%u:%g",
         file
-    ], stdout=subprocess.PIPE, encoding="utf-8")
+    ], stdout=subprocess.PIPE, encoding="utf-8", check=True)
+    return res.stdout.strip()
+
+def get_mode(fr: FakeRoot, file: Path) -> int:
+    if not fr:
+        fr = subprocess
+    res = fr.run([
+        "stat",
+        "-c", "%a",
+        file
+    ], stdout=subprocess.PIPE, encoding="utf-8", check=True)
+    return int(res.stdout, 8)
+
+def get_node(fr: FakeRoot, file: Path) -> str:
+    if not fr:
+        fr = subprocess
+    res = fr.run([
+        "stat",
+        "-c", "%f:%t:%T",
+        file
+    ], stdout=subprocess.PIPE, encoding="utf-8", check=True)
+    mode, major, minor = map(lambda x: int(x, 16), res.stdout.strip().split(":"))
+    mode = stat.filemode(mode)[0]
+    return f"{mode}:{major}:{minor}"
+
+def get_symlink(fr: FakeRoot, file: Path) -> str:
+    if not fr:
+        fr = subprocess
+    res = fr.run([
+        "readlink",
+        file
+    ], stdout=subprocess.PIPE, encoding="utf-8", check=True)
     return res.stdout.strip()
 
 def test_simple(tmp_path: Path):
@@ -86,3 +122,66 @@ def test_run(tmp_path: Path):
         fr.run(["false"])
 
     fr.run(["false"], check=False)
+
+
+def test_copy(tmp_path: Path):
+    savefile1 = tmp_path / "fakeroot1.save"
+    savefile2 = tmp_path / "fakeroot2.save"
+    src = tmp_path / "src"
+    dst = tmp_path / "dst"
+    fr = FakeRoot(savefile1)
+
+    src.mkdir()
+
+    fr.run(["chown", "678:900", src])
+    fr.run(["chmod", "0712", src])
+    fr.run(["touch", src / "file_a"])
+    fr.run(["chmod", "ogu+rwxs", src / "file_a"])
+    fr.run(["chown", "123:456", src / "file_a"])
+    fr.run(["mknod", src / "node", "c", str(123), str(456)])
+
+    fr.run(["ln", "-s", "/i/do/not/exist", src / "invalid_symlink"])
+
+    os.mkfifo(src / "fifo", 0o621)
+    fr.run(["chown", "666:999", src / "fifo"])
+
+
+    fr2 = FakeRoot(savefile2, fr)
+
+    fr2.copy(src, dst)
+    fr2.copy(src / "file_a", dst)
+
+    # A guaranteed device file
+    fr2.copy("/dev/null", dst)
+    fr2.copy("/dev/loop0", dst)
+
+    # A guaranteed file on another filesystem, to trigger the copy instead of hardlink path
+    fr2.copy("/proc/self/environ", dst)
+
+    assert get_mode(fr2, dst / "src") == 0o712
+    assert get_uid_and_gid(fr2, dst / "src") == "678:900"
+    assert get_uid_and_gid(fr2, dst / "src/file_a") == "123:456"
+
+    assert get_uid_and_gid(fr2, dst / "file_a") == "123:456"
+    assert get_mode(fr2, dst / "file_a") == 0o6777
+
+    assert get_uid_and_gid(fr2, dst / "src/node") == "0:0"
+    assert get_node(fr2, dst / "src/node") == "c:123:456"
+
+    assert get_symlink(fr2, dst / "src/invalid_symlink") == "/i/do/not/exist"
+
+    assert get_node(fr2, dst / "src/fifo") == "p:0:0"
+    assert get_mode(fr2, dst / "src/fifo") == calc_umask(0o621)
+    assert get_uid_and_gid(fr2, dst / "src/fifo") == "666:999"
+
+    assert get_mode(fr2, dst / "null") == get_mode(None, "/dev/null")
+    assert get_node(fr2, dst / "null") == get_node(None, "/dev/null")
+    assert get_uid_and_gid(fr2, dst / "null") == get_uid_and_gid(None, "/dev/null")
+
+    assert get_mode(fr2, dst / "loop0") == get_mode(None, "/dev/loop0")
+    assert get_node(fr2, dst / "loop0") == get_node(None, "/dev/loop0")
+    assert get_uid_and_gid(fr2, dst / "loop0") == get_uid_and_gid(None, "/dev/loop0")
+
+    assert (dst / "environ").exists()
+    assert (dst / "environ").is_file()
+    assert (dst / "environ").stat().st_size != 0

--- a/embdgen-core/tests/utils/test_FakeRoot.py
+++ b/embdgen-core/tests/utils/test_FakeRoot.py
@@ -77,16 +77,6 @@ def test_inherit(tmp_path: Path):
     assert get_uid_and_gid(fr, file2) == "123:456"
 
 
-def test_parent_parent(tmp_path: Path):
-    savefile1 = tmp_path / "fakeroot1.save"
-
-    fr = FakeRoot(savefile1)
-    fr2 = FakeRoot(savefile1, fr)
-
-    with pytest.raises(Exception, match="FakeRoot parent has already a parent. Recursive parenting is not allowed."):
-        FakeRoot(savefile1, fr2)
-
-
 def test_run(tmp_path: Path):
     savefile1 = tmp_path / "fakeroot1.save"
 

--- a/off-embdgen-config-xml/README.md
+++ b/off-embdgen-config-xml/README.md
@@ -1,0 +1,1 @@
+# EMBedded Disk GENerator xml config loader

--- a/off-embdgen-config-xml/pyproject.toml
+++ b/off-embdgen-config-xml/pyproject.toml
@@ -1,0 +1,49 @@
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[tool.hatch.version]
+path = "src/embdgen/plugins/config/XML.py"
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/embdgen"]
+
+[project]
+name = "embdgen-config-xml"
+dynamic = ["version"]
+
+authors = [
+  { name="AOX GmbH", email="info@aox.de" },
+  { name="Elektrobit GmbH", email="info@elektrobit.com" },
+]
+description = "XML config loader for the EMBedded Disk GENerator (embdgen)"
+readme = "README.md"
+classifiers = [
+    "Programming Language :: Python :: 3",
+    "License :: OSI Approved :: MIT License",
+    "Operating System :: POSIX :: Linux",
+]
+requires-python = ">=3.8"
+dependencies = [
+    "embdgen-core",
+    "xmlschema",
+    "lxml"
+]
+
+[project.urls]
+Homepage = "https://github.com/Elektrobit/embdgen"
+
+
+[tool.pylint.format]
+max-line-length = 120
+
+[tool.pylint.'MESSAGES CONTROL']
+disable = [
+    'missing-module-docstring',
+    'missing-function-docstring',
+    'missing-class-docstring',
+    'invalid-name',
+    'broad-exception-raised',
+    'too-few-public-methods',
+    'too-many-instance-attributes'
+]


### PR DESCRIPTION
The implementation to create a directory to be passed to mkfs was broken.
 It did not correctly copy all permissions and tried to copy files that are reachable through
 symlinked directories.
 With the FakeRoot implementation symlinks are just recreated and not followed.