### PR TITLE
label: add support for efi system partitions

### DIFF
--- a/embdgen-core/src/embdgen/plugins/region/PartitionRegion.py
+++ b/embdgen-core/src/embdgen/plugins/region/PartitionRegion.py
@@ -19,7 +19,10 @@ class PartitionRegion(BaseContentRegion):
     """Content of this Region"""
 
     fstype: str
-    """Filesystem type of this region (e.g. ext4, fat32)"""
+    """
+    Filesystem type of this region (e.g. ext4, fat32)
+    An EFI system partition for gpt and mbr partition tables can be created with "esp"
+    """
 
     def write(self, out_file: BufferedIOBase):
         out_file.seek(self.start.bytes)

--- a/embdgen-core/tests/label/test_GPT.py
+++ b/embdgen-core/tests/label/test_GPT.py
@@ -273,3 +273,22 @@ class TestGPT:
         assert output_w_offset_2 == (b"DATA" * 512)
         output = capsys.readouterr().out
         assert output == "The location for the GPT Partition Table is used by another region. Table will be relocated\n"
+
+    def test_efi_system(self, tmp_path: Path) -> None:
+        image = tmp_path / "image"
+        obj = GPT()        
+
+        esp = PartitionRegion()
+        esp.name = "EFI system partition"
+        esp.size = SizeType.parse("100 MB")
+        esp.fstype = "esp"
+        esp.content = EmptyContent()
+
+        obj.parts.append(esp)
+
+        obj.prepare()
+        obj.create(image)
+
+        fdisk = FdiskParser(image)
+        assert fdisk.is_valid
+        assert fdisk.regions[0].type_id == FdiskRegion.TYPE_ESP

--- a/embdgen-core/tests/label/test_MBR.py
+++ b/embdgen-core/tests/label/test_MBR.py
@@ -1,10 +1,7 @@
 # SPDX-License-Identifier: GPL-3.0-only
 
-from typing import List
-import re
 from pathlib import Path
 import subprocess
-from dataclasses import dataclass
 
 from embdgen.core.utils.image import BuildLocation
 from embdgen.core.utils.SizeType import SizeType
@@ -18,76 +15,8 @@ from embdgen.plugins.content.RawContent import RawContent
 from embdgen.plugins.content.FilesContent import FilesContent
 from embdgen.plugins.content.Fat32Content import Fat32Content
 
-@dataclass
-class FdiskRegion:
-    start_sector: int
-    end_sector: int
-    sectors: int
-    type_id: int
-    boot: bool
+from ..test_utils.FdiskParser import FdiskParser, FdiskRegion
 
-
-class FdiskParser:
-    TYPE_FAT32_LBA = 0x0C
-    TYPE_LINUX_NATIVE = 0x83
-    TYPE_EXTENDED = 0x05
-
-
-    is_valid: bool = False
-    diskid: int = None
-    regions: List[FdiskRegion]
-
-    def __init__(self, image):
-        self.regions = []
-        ret = subprocess.run([
-            'fdisk',
-            '-l',
-            image
-        ], stdout=subprocess.PIPE, check=False, encoding="ascii")
-        if ret.returncode == 0:
-            self.is_valid = True
-        self._parse(ret.stdout)
-
-    def _parse(self, output: str):
-        """
-        Disk image: 5,1 MiB, 5250560 bytes, 10255 sectors
-        Units: sectors of 1 * 512 = 512 bytes
-        Sector size (logical/physical): 512 bytes / 512 bytes
-        I/O size (minimum/optimal): 512 bytes / 512 bytes
-        Disklabel type: dos
-        Disk identifier: 0x5a30abff
-
-        Device                                                 Boot Start   End Sectors Size Id Type
-        image1 *       13    14       2   1K 83 Linux
-        image2         15 10254   10240   5M  b W95 FAT32
-
-        """
-        in_regions = False
-        for line in output.splitlines():
-            if in_regions:
-                parts = re.split(r"\s+", line)
-                if not parts[1] == "*":
-                    parts.insert(1, "")
-                _, boot, start, end, sectors, _, tyoe_id, *_ = parts
-                self.regions.append(FdiskRegion(
-                    int(start),
-                    int(end),
-                    int(sectors),
-                    int(tyoe_id, 16),
-                    boot == "*"
-                ))
-
-            else:
-                if line.startswith("Disk identifier:"):
-                    self.diskid = int(line.split(":")[1], 16)
-                elif line.startswith("Device"):
-                    in_regions = True
-
-    def __repr__(self) -> str:
-        out = []
-        for i, r in enumerate(self.regions):
-            out.append(f"{i} {r.start_sector:>5} - {r.start_sector + r.sectors:>5} ({r.sectors:>4} Sectors), {r.type_id}")
-        return "\n".join(out)
 
 class TestMBR:
     def test_empty(self, tmp_path: Path):
@@ -120,7 +49,7 @@ class TestMBR:
         fdisk = FdiskParser(image)
 
         assert fdisk.is_valid
-        assert fdisk.diskid == 0xdeadbeef
+        assert fdisk.diskid == "0xdeadbeef"
 
     def test_withParts(self, tmp_path):
         BuildLocation().set_path(tmp_path)
@@ -164,10 +93,10 @@ class TestMBR:
         assert fdisk.is_valid
         assert len(fdisk.regions) == 2
         assert fdisk.regions[0].start_sector == 13
-        assert fdisk.regions[0].type_id == FdiskParser.TYPE_LINUX_NATIVE
+        assert fdisk.regions[0].type_id == FdiskRegion.TYPE_LINUX_NATIVE
         assert fdisk.regions[0].boot
         assert fdisk.regions[1].start_sector == 15
-        assert fdisk.regions[1].type_id == FdiskParser.TYPE_FAT32_LBA
+        assert fdisk.regions[1].type_id == FdiskRegion.TYPE_FAT32_LBA
 
     def test_four_partitions_no_extended(self, tmp_path: Path):
         BuildLocation().set_path(tmp_path)
@@ -188,7 +117,7 @@ class TestMBR:
         assert fdisk.is_valid
         assert len(fdisk.regions) == 4
         for i in range(4):
-            assert fdisk.regions[i].type_id == FdiskParser.TYPE_LINUX_NATIVE
+            assert fdisk.regions[i].type_id == FdiskRegion.TYPE_LINUX_NATIVE
 
     def test_extended_with_empty(self, tmp_path: Path):
         BuildLocation().set_path(tmp_path)
@@ -215,13 +144,13 @@ class TestMBR:
         assert len(fdisk.regions) == 8
         pos = 1
         for i in range(3):
-            assert fdisk.regions[i].type_id == FdiskParser.TYPE_LINUX_NATIVE
+            assert fdisk.regions[i].type_id == FdiskRegion.TYPE_LINUX_NATIVE
             assert fdisk.regions[i].start_sector == pos
             pos += SizeType.parse("1MB").sectors
-        assert fdisk.regions[3].type_id == FdiskParser.TYPE_EXTENDED
+        assert fdisk.regions[3].type_id == FdiskRegion.TYPE_EXTENDED
         for i in range(4, 8):
             pos += 1
-            assert fdisk.regions[i].type_id == FdiskParser.TYPE_LINUX_NATIVE
+            assert fdisk.regions[i].type_id == FdiskRegion.TYPE_LINUX_NATIVE
             assert fdisk.regions[i].start_sector == pos
             pos += SizeType.parse("1MB").sectors
             if i == 4:

--- a/embdgen-core/tests/label/test_MBR.py
+++ b/embdgen-core/tests/label/test_MBR.py
@@ -155,3 +155,22 @@ class TestMBR:
             pos += SizeType.parse("1MB").sectors
             if i == 4:
                 pos += 12 # Empty partition
+
+    def test_efi_system(self, tmp_path: Path) -> None:
+        image = tmp_path / "image"
+        obj = MBR()        
+
+        esp = PartitionRegion()
+        esp.name = "EFI system partition"
+        esp.size = SizeType.parse("100 MB")
+        esp.fstype = "esp"
+        esp.content = EmptyContent()
+
+        obj.parts.append(esp)
+
+        obj.prepare()
+        obj.create(image)
+
+        fdisk = FdiskParser(image)
+        assert fdisk.is_valid
+        assert fdisk.regions[0].type_id == FdiskRegion.TYPE_ESP

--- a/embdgen-core/tests/test_utils/FdiskParser.py
+++ b/embdgen-core/tests/test_utils/FdiskParser.py
@@ -8,7 +8,7 @@ class FdiskRegion:
     TYPE_FAT32_LBA = 0x0C
     TYPE_LINUX_NATIVE = 0x83
     TYPE_EXTENDED = 0x05
-    TYPE_EFS = 0xEF
+    TYPE_ESP = 0xEF
 
     start_sector: int
     end_sector: int
@@ -71,7 +71,7 @@ class FdiskParser:
                 elif self.label_type == "gpt":
                     type_id = " ".join([type_id, *type_id_ext]).lower()
                     if type_id == "efi system":
-                        type_id = FdiskRegion.TYPE_EFS
+                        type_id = FdiskRegion.TYPE_ESP
                     elif type_id == "microsoft basic data":
                         type_id = FdiskRegion.TYPE_FAT32_LBA
                     else:

--- a/embdgen-core/tests/test_utils/FdiskParser.py
+++ b/embdgen-core/tests/test_utils/FdiskParser.py
@@ -1,0 +1,102 @@
+import re
+from typing import List
+from dataclasses import dataclass
+import subprocess
+
+@dataclass
+class FdiskRegion:
+    TYPE_FAT32_LBA = 0x0C
+    TYPE_LINUX_NATIVE = 0x83
+    TYPE_EXTENDED = 0x05
+    TYPE_EFS = 0xEF
+
+    start_sector: int
+    end_sector: int
+    sectors: int
+    type_id: int
+    boot: bool
+
+
+class FdiskParser:
+    is_valid: bool = False
+    label_type: str = None
+    diskid: int = None
+    regions: List[FdiskRegion]
+
+    def __init__(self, image):
+        self.regions = []
+        ret = subprocess.run([
+            'fdisk',
+            '-l',
+            image
+        ], stdout=subprocess.PIPE, check=False, encoding="ascii")
+        if ret.returncode == 0:
+            self.is_valid = True
+        self._parse(ret.stdout)
+
+    def _parse(self, output: str):
+        """
+        Disk image: 5,1 MiB, 5250560 bytes, 10255 sectors
+        Units: sectors of 1 * 512 = 512 bytes
+        Sector size (logical/physical): 512 bytes / 512 bytes
+        I/O size (minimum/optimal): 512 bytes / 512 bytes
+        Disklabel type: dos
+        Disk identifier: 0x5a30abff
+
+        Device       Boot Start   End Sectors Size Id Type
+        image1 *       13    14       2   1K 83 Linux
+        image2         15 10254   10240   5M  b W95 FAT32
+
+        
+        Disk /image: 100,3 MiB, 104891904 bytes, 204867 sectors
+        Units: sectors of 1 * 512 = 512 bytes
+        Sector size (logical/physical): 512 bytes / 512 bytes
+        I/O size (minimum/optimal): 512 bytes / 512 bytes
+        Disklabel type: gpt
+        Disk identifier: 9F781A13-49F0-4436-A1DA-845216AADF83
+
+        Device Start    End Sectors  Size Type
+        image1    34 204833  204800  100M EFI System
+
+        """
+        in_regions = False
+        for line in output.splitlines():
+            if in_regions:
+                parts = re.split(r"\s+", line)
+                if not parts[1] == "*":
+                    parts.insert(1, "")
+                _, boot, start, end, sectors, _, type_id, *type_id_ext = parts
+                if self.label_type == "dos":
+                    type_id = int(type_id, 16)
+                elif self.label_type == "gpt":
+                    type_id = " ".join([type_id, *type_id_ext]).lower()
+                    if type_id == "efi system":
+                        type_id = FdiskRegion.TYPE_EFS
+                    elif type_id == "microsoft basic data":
+                        type_id = FdiskRegion.TYPE_FAT32_LBA
+                    else:
+                        raise Exception(f"Unimplemented partition type for gpt: {type_id}")
+                else:
+                    raise Exception(f"Unexpected label type in fdisk output: {self.label_type}")
+
+                self.regions.append(FdiskRegion(
+                    int(start),
+                    int(end),
+                    int(sectors),
+                    type_id,
+                    boot == "*"
+                ))
+
+            else:
+                if line.startswith("Disklabel type:"):
+                    self.label_type  = line.split(":")[1].strip()
+                if line.startswith("Disk identifier:"):
+                    self.diskid = line.split(":")[1].strip()
+                elif line.startswith("Device"):
+                    in_regions = True
+
+    def __repr__(self) -> str:
+        out = []
+        for i, r in enumerate(self.regions):
+            out.append(f"{i} {r.start_sector:>5} - {r.start_sector + r.sectors:>5} ({r.sectors:>4} Sectors), {r.type_id}")
+        return "\n".join(out)


### PR DESCRIPTION
partition.fstype can be set to "esp" now, to create an efi system partition
on gpt and mbr partition tables.