### PR TITLE
Fat32Content: enforce fat32

### DIFF
--- a/embdgen-core/src/embdgen/plugins/content/Fat32Content.py
+++ b/embdgen-core/src/embdgen/plugins/content/Fat32Content.py
@@ -40,6 +40,7 @@ class Fat32Content(BinaryContent):
 
         subprocess.run([
                 "mkfs.vfat",
+                "-F", "32",
                 self.result_file
             ],
             check=True,

--- a/embdgen-core/tests/test_utils/SimpleCommandParser.py
+++ b/embdgen-core/tests/test_utils/SimpleCommandParser.py
@@ -21,7 +21,7 @@ class SimpleCommandParser(abc.ABC):
         self.ok = ret.returncode == 0
 
         for line in ret.stdout.splitlines():
-            splits = re.split(r":\s+", line.strip(), 1)
+            splits = re.split(r"[:=]", line.strip(), 1)
             if len(splits) != 2:
                 continue
             key, value = splits


### PR DESCRIPTION
mkfs.vfat can create fat 12, 16 and 32.
By default it uses whatever fits best.
Since the module is called Fat32, it should always create a fat32 filesystem